### PR TITLE
refactor(edit-column): use focusous instead of blur

### DIFF
--- a/demo/pro-grid-edit-column-demos.html
+++ b/demo/pro-grid-edit-column-demos.html
@@ -163,7 +163,7 @@
     <p>
       The custom editor component can be rendered for cell edit mode using <b><code>editModeRenderer</code></b>.
       The component must be first child of the edited cell content, and should be focusable (grid will exit
-      cell edit mode on blur). If component is an <code>&lt;input&gt;</code>, it will be selected.
+      cell edit mode on focusout). If component is an <code>&lt;input&gt;</code>, it will be selected.
     </p>
     <p>
       By default, cell value corresponding to the column <code>path</code> is mapped to the <code>value</code>

--- a/src/vaadin-pro-grid-edit-column.html
+++ b/src/vaadin-pro-grid-edit-column.html
@@ -228,7 +228,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         this._renderEditor(cell, model);
         this._grid.notifyResize();
         const editor = this._getEditorComponent(cell);
-        editor.addEventListener('blur', this._grid.__boundEditorBlur);
+        editor.addEventListener('focusout', this._grid.__boundEditorFocusOut);
         this._setEditorValue(editor, Polymer.Path.get(model.item, this.path));
         this._focusEditor(editor);
       }
@@ -254,7 +254,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         const editor = this._getEditorComponent(cell);
         let shouldResize = true;
         if (editor) {
-          editor.removeEventListener('blur', this._grid.__boundEditorBlur);
+          editor.removeEventListener('focusout', this._grid.__boundEditorFocusOut);
         } else {
           // avoid notify resize of editor removed due to scroll
           shouldResize = false;

--- a/src/vaadin-pro-grid-inline-editing-mixin.html
+++ b/src/vaadin-pro-grid-inline-editing-mixin.html
@@ -44,7 +44,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
     constructor() {
       super();
       this.__boundItemPropertyChanged = this._onItemPropertyChanged.bind(this);
-      this.__boundEditorBlur = this._onEditorBlur.bind(this);
+      this.__boundEditorFocusOut = this._onEditorFocusOut.bind(this);
     }
 
     ready() {
@@ -139,8 +139,8 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       }
     }
 
-    _onEditorBlur() {
-      // schedule stop on editor component blur
+    _onEditorFocusOut() {
+      // schedule stop on editor component focusout
       this._debouncerStopEdit = Polymer.Debouncer.debounce(
         this._debouncerStopEdit,
         Polymer.Async.timeOut.after(200),
@@ -148,7 +148,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
     }
 
     _startEdit(cell, column) {
-      // cancel debouncer enqueued on blur
+      // cancel debouncer enqueued on focusout
       this._cancelStopEdit();
 
       this._scrollHorizontallyToCell(cell);

--- a/test/edit-column.html
+++ b/test/edit-column.html
@@ -572,7 +572,7 @@
           expect(spy).to.be.calledOnce;
         });
 
-        it('should exit the edit mode on custom editor component blur event', () => {
+        it('should exit the edit mode on custom editor component focusout event', () => {
           column.editModeRenderer = function(root, owner, model) {
             root.innerHTML = '';
             const input = document.createElement('input');
@@ -583,7 +583,7 @@
           dblclick(cell._content);
           editor = getCellEditor(cell);
           editor.value = 'Foo';
-          editor.dispatchEvent(new CustomEvent('blur', {bubbles: false}));
+          editor.dispatchEvent(new CustomEvent('focusout', {bubbles: true, composed: true}));
           grid._flushStopEdit();
           expect(getCellEditor(cell)).to.not.be.ok;
           expect(cell._content.textContent).to.equal('Foo');


### PR DESCRIPTION
Needed for select type editor, to prevent exit edit mode when moving focus to `vaadin-select-overlay`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-pro/22)
<!-- Reviewable:end -->
