### PR TITLE
refactor(edit-column): leave editorType empty by default

### DIFF
--- a/src/vaadin-grid-pro-edit-column.html
+++ b/src/vaadin-grid-pro-edit-column.html
@@ -66,7 +66,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
           /**
            * Type of the cell editor component to be rendered. Allowed values:
-           * - `text` (default) - renders a text field
+           * - `text` (default, also applies when no value set) - renders a text field
            * - `boolean` - renders a checkbox
            * - `select` - renders a select with a list of items passed as `editorOptions`
            *
@@ -74,8 +74,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
            * or editor template provided for the column.
            */
           editorType: {
-            type: String,
-            value: 'text'
+            type: String
           },
 
           /**
@@ -135,7 +134,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         if (template && renderer) {
           throw new Error('You should only use either a renderer or a template');
         }
-        this.editorType = (template || renderer) ? 'custom' : 'text';
+        this.editorType = (template || renderer) ? 'custom' : undefined;
       }
 
       /**

--- a/test/edit-column.html
+++ b/test/edit-column.html
@@ -610,12 +610,12 @@
           expect(column.editorType).to.be.equal('custom');
         });
 
-        it('should reset the column `editorType` to text when renderer is removed', () => {
+        it('should reset the column `editorType` to undefined when renderer is removed', () => {
           column.editModeRenderer = function(root, owner, model) {
             root.innerHTML = '<input>';
           };
           column.editModeRenderer = null;
-          expect(column.editorType).to.be.equal('text');
+          expect(column.editorType).to.be.equal(undefined);
         });
 
         it('should throw an error when setting a template if there is already a renderer', () => {
@@ -673,9 +673,9 @@
           expect(column.editorType).to.be.equal('custom');
         });
 
-        it('should reset the column `editorType` to text when template is removed', () => {
+        it('should reset the column `editorType` to undefined when template is removed', () => {
           column._editModeTemplate = null;
-          expect(column.editorType).to.be.equal('text');
+          expect(column.editorType).to.be.equal(undefined);
         });
 
         it('should throw an error when setting a renderer if there is already a template', () => {


### PR DESCRIPTION
The default value is not actually required to be present in the web component, and removal will make it easier to handle in Flow counterpart. No demo change needed, as we do not highlight `text` there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-pro/29)
<!-- Reviewable:end -->
