### PR TITLE
fix(edit-column): notify editor type change [skip ci]

### DIFF
--- a/src/vaadin-grid-pro-edit-column.html
+++ b/src/vaadin-grid-pro-edit-column.html
@@ -75,6 +75,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
            */
           editorType: {
             type: String,
+            notify: true, // FIXME(web-padawan): needed by Flow counterpart
             value: 'text'
           },
 


### PR DESCRIPTION
Same as #27. Turns out the Flow counterpart needs this workaround to make sure the web component default value is in sync and to prevent it from overriding the value set on the server side.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-pro/35)
<!-- Reviewable:end -->
