### PR TITLE
Pre-open select on activate, exit edit mode on select

### DIFF
--- a/src/vaadin-grid-pro-edit-select.html
+++ b/src/vaadin-grid-pro-edit-select.html
@@ -39,7 +39,8 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       static get properties() {
         return {
           value: {
-            type: String
+            type: String,
+            observer: '_valueChanged'
           },
 
           options: {
@@ -49,6 +50,10 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
           _grid: {
             type: Object
+          },
+
+          _initialized: {
+            type: Boolean
           },
 
           _select: {
@@ -94,6 +99,16 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         }
       }
 
+      _valueChanged(value, oldValue) {
+        // select is first created without a value
+        if (value === '' && oldValue === undefined) {
+          return;
+        }
+        if (this._initialized) {
+          this._grid._stopEdit();
+        }
+      }
+
       _optionsChanged(select, options) {
         if (select && options && options.length) {
           select.renderer = root => {
@@ -121,6 +136,8 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
           Polymer.RenderStatus.afterNextRender(select, () => {
             select.opened = true;
+            // any value change after first open will stop edit
+            this._initialized = true;
           });
         }
       }

--- a/src/vaadin-grid-pro-edit-select.html
+++ b/src/vaadin-grid-pro-edit-select.html
@@ -118,6 +118,10 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           this._overlay.addEventListener('vaadin-overlay-outside-click', e => {
             this._grid._stopEdit();
           });
+
+          Polymer.RenderStatus.afterNextRender(select, () => {
+            select.opened = true;
+          });
         }
       }
     }

--- a/test/edit-column.html
+++ b/test/edit-column.html
@@ -832,11 +832,10 @@
           expect(select.opened).to.equal(true);
         });
 
-        it('should update value from selected one after edit mode exit', () => {
+        it('should update value and exit edit mode when item is selected', () => {
           const item = editor._overlay.querySelector('vaadin-item');
           const value = item.textContent;
           item.click();
-          tab(select);
           expect(column._getEditorComponent(cell)).to.not.be.ok;
           expect(cell._content.textContent).to.equal(value);
         });

--- a/test/edit-column.html
+++ b/test/edit-column.html
@@ -792,12 +792,14 @@
           await nextRender(select);
         });
 
-        it('should render the select to cell in edit mode', async() => {
+        it('should render the opened select to cell in edit mode', () => {
           expect(select instanceof Vaadin.SelectElement).to.equal(true);
           expect(select.value).to.be.equal('mrs');
+          expect(select.opened).to.equal(true);
         });
 
         it('should open the select and stop focusout on editor click', async() => {
+          select.opened = false;
           select.focusElement.click();
           const evt = new CustomEvent('focusout', {bubbles: true, composed: true});
           evt.relatedTarget = editor._overlay.querySelector('vaadin-item');
@@ -807,17 +809,9 @@
           expect(select.opened).to.equal(true);
         });
 
-        it('should close the select and exit edit mode on outside click', async() => {
-          select.focusElement.click();
-          await nextRender(select._menuElement);
+        it('should close the select and exit edit mode on outside click', () => {
           document.body.click();
           expect(select.opened).to.equal(false);
-        });
-
-        it('should open the select on enter key', async() => {
-          enter(select.focusElement);
-          await nextRender(select._menuElement);
-          expect(select.opened).to.equal(true);
         });
 
         it('should open the select on space key', async() => {
@@ -838,9 +832,7 @@
           expect(select.opened).to.equal(true);
         });
 
-        it('should update value from selected one after edit mode exit', async() => {
-          enter(select.focusElement);
-          await nextRender(select._menuElement);
+        it('should update value from selected one after edit mode exit', () => {
           const item = editor._overlay.querySelector('vaadin-item');
           const value = item.textContent;
           item.click();


### PR DESCRIPTION
Fixes #42 

Had to add the flag in order to track initialisation, as in theory editor options could contain empty string, and to avoid any assumptions based on the old value etc.