### PR TITLE
fix: workaround dblclick entering edit mode iOS Safari

### DIFF
--- a/src/vaadin-grid-pro-inline-editing-mixin.html
+++ b/src/vaadin-grid-pro-inline-editing-mixin.html
@@ -53,9 +53,33 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
     ready() {
       super.ready();
 
-      this.addEventListener('dblclick', e => {
-        this._enterEditFromEvent(e);
-      });
+      // dblclick does not work on iOS Safari
+      if (this._ios) {
+        let firstClickTime;
+        let waitingSecondClick = false;
+
+        this.addEventListener('click', e => {
+          if (!waitingSecondClick) {
+            firstClickTime = (new Date()).getTime();
+            waitingSecondClick = true;
+
+            setTimeout(() => {
+              waitingSecondClick = false;
+            }, 300);
+          } else {
+            waitingSecondClick = false;
+
+            const time = (new Date()).getTime();
+            if (time - firstClickTime < 300) {
+              this._enterEditFromEvent(e);
+            }
+          }
+        });
+      } else {
+        this.addEventListener('dblclick', e => {
+          this._enterEditFromEvent(e);
+        });
+      }
 
       this.addEventListener('keydown', e => {
         switch (e.keyCode) {

--- a/test/edit-column.html
+++ b/test/edit-column.html
@@ -102,6 +102,8 @@
   </dom-module>
 
   <script>
+    const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+
     function getItems() {
       return [
         {name: 'foo', age: 20, married: true, title: 'mrs'},
@@ -111,7 +113,12 @@
     }
 
     function dblclick(target) {
-      target.dispatchEvent(new CustomEvent('dblclick', {bubbles: true, composed: true}));
+      if (isIOS) {
+        target.dispatchEvent(new CustomEvent('click', {bubbles: true, composed: true}));
+        target.dispatchEvent(new CustomEvent('click', {bubbles: true, composed: true}));
+      } else {
+        target.dispatchEvent(new CustomEvent('dblclick', {bubbles: true, composed: true}));
+      }
     }
 
     function up(target) {
@@ -156,7 +163,7 @@
         return cell._column._getEditorComponent(cell);
       }
 
-      describe('keyboard navigation', () => {
+      !isIOS && describe('keyboard navigation', () => {
         let grid, input;
 
         beforeEach(() => {
@@ -504,7 +511,7 @@
           cell = getContainerCell(grid.$.items, 0, 0);
         });
 
-        it('should replace template and render text-field on editable cell click', () => {
+        it('should replace template and render text-field on editable cell dblclick', () => {
           dblclick(cell._content);
           expect(cell._template).to.be.not.ok;
           expect(cell._renderer).to.be.ok;


### PR DESCRIPTION
Fixes #48 

Tested in Simulator. Have no idea how to test it better than dispatching 2 click events.
Also, disabled keyboard navigation tests for iOS as it does not make any sense there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-pro/56)
<!-- Reviewable:end -->
