### PR TITLE
Refactor: rename confusing preserveEditMode and allowEnterRowChange

### DIFF
--- a/demo/grid-pro-edit-column-demos.html
+++ b/demo/grid-pro-edit-column-demos.html
@@ -126,19 +126,19 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Preserve Edit Mode</h3>
+    <h3>Keep Editor Open</h3>
     <p>
-      When <code>preserveEditMode</code> is set on the grid element, focusing the next editable cell from keyboard will activate edit mode for it.
+      When <code>keepEditorOpen</code> is set on the grid element, focusing the next editable cell from keyboard will activate edit mode for it.
     </p>
-    <vaadin-demo-snippet id="grid-pro-edit-column-demos-preserve-edit-mode" when-defined="vaadin-grid-pro">
+    <vaadin-demo-snippet id="grid-pro-edit-column-demos-keep-editor-open" when-defined="vaadin-grid-pro">
       <template preserve-content>
-        <vaadin-grid-pro preserve-edit-mode enter-next-row>
+        <vaadin-grid-pro keep-editor-open enter-next-row>
           <vaadin-grid-pro-edit-column path="name.first" header="First name (edit)"></vaadin-grid-pro-edit-column>
           <vaadin-grid-column path="name.last" header="Last name (view)"></vaadin-grid-column>
           <vaadin-grid-pro-edit-column path="name.last" header="Last name (edit)"></vaadin-grid-pro-edit-column>
         </vaadin-grid-pro>
         <script>
-          window.addDemoReadyListener('#grid-pro-edit-column-demos-preserve-edit-mode', function(document) {
+          window.addDemoReadyListener('#grid-pro-edit-column-demos-keep-editor-open', function(document) {
             document.querySelector('vaadin-grid-pro').items = Vaadin.GridDemo.getUsers();
           });
         </script>

--- a/demo/grid-pro-edit-column-demos.html
+++ b/demo/grid-pro-edit-column-demos.html
@@ -103,23 +103,23 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Allow Enter Row Change</h3>
+    <h3>Use Enter to Focus Next Row</h3>
     <p>
-      When <code>allowEnterRowChange</code> is set on the grid element, the following keys <b>change behavior</b>:
+      When <code>enterNextRow</code> is set on the grid element, the following keys <b>change behavior</b>:
     </p>
     <ul>
       <li><kbd>Enter</kbd> - save changes, exit the edit mode <b>and</b> focus the editable cell in the next row</li>
       <li><kbd>Shift</kbd> + <kbd>Enter</kbd> - save changes, exit the edit mode <b>and</b> focus the editable cell in the previous row</li>
     </ul>
-    <vaadin-demo-snippet id="grid-pro-edit-column-demos-allow-enter-row-change" when-defined="vaadin-grid-pro">
+    <vaadin-demo-snippet id="grid-pro-edit-column-demos-enter-next-row" when-defined="vaadin-grid-pro">
       <template preserve-content>
-        <vaadin-grid-pro allow-enter-row-change>
+        <vaadin-grid-pro enter-next-row>
           <vaadin-grid-pro-edit-column path="name.first" header="First name (edit)"></vaadin-grid-pro-edit-column>
           <vaadin-grid-column path="name.last" header="Last name (view)"></vaadin-grid-column>
           <vaadin-grid-pro-edit-column path="name.last" header="Last name (edit)"></vaadin-grid-pro-edit-column>
         </vaadin-grid-pro>
         <script>
-          window.addDemoReadyListener('#grid-pro-edit-column-demos-allow-enter-row-change', function(document) {
+          window.addDemoReadyListener('#grid-pro-edit-column-demos-enter-next-row', function(document) {
             document.querySelector('vaadin-grid-pro').items = Vaadin.GridDemo.getUsers();
           });
         </script>
@@ -132,7 +132,7 @@
     </p>
     <vaadin-demo-snippet id="grid-pro-edit-column-demos-preserve-edit-mode" when-defined="vaadin-grid-pro">
       <template preserve-content>
-        <vaadin-grid-pro preserve-edit-mode allow-enter-row-change>
+        <vaadin-grid-pro preserve-edit-mode enter-next-row>
           <vaadin-grid-pro-edit-column path="name.first" header="First name (edit)"></vaadin-grid-pro-edit-column>
           <vaadin-grid-column path="name.last" header="Last name (view)"></vaadin-grid-column>
           <vaadin-grid-pro-edit-column path="name.last" header="Last name (edit)"></vaadin-grid-pro-edit-column>

--- a/src/vaadin-grid-pro-edit-select.html
+++ b/src/vaadin-grid-pro-edit-select.html
@@ -107,7 +107,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         }
         if (this._initialized) {
           const enter = this._enterKeydown;
-          if (enter && this._grid.allowEnterRowChange) {
+          if (enter && this._grid.enterNextRow) {
             this._grid._switchEditCell(enter);
           } else if (!this._grid.preserveEditMode) {
             this._grid._stopEdit();

--- a/src/vaadin-grid-pro-edit-select.html
+++ b/src/vaadin-grid-pro-edit-select.html
@@ -109,7 +109,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           const enter = this._enterKeydown;
           if (enter && this._grid.enterNextRow) {
             this._grid._switchEditCell(enter);
-          } else if (!this._grid.preserveEditMode) {
+          } else if (!this._grid.keepEditorOpen) {
             this._grid._stopEdit();
           }
         }

--- a/src/vaadin-grid-pro-inline-editing-mixin.html
+++ b/src/vaadin-grid-pro-inline-editing-mixin.html
@@ -40,7 +40,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
          * When `enterNextRow` is true, pressing Enter will also
          * preserve edit mode, otherwise, it will have no effect.
          */
-        preserveEditMode: {
+        keepEditorOpen: {
           type: Boolean,
           notify: true // FIXME(yuriy-fix): needed by Flow counterpart
         }
@@ -293,7 +293,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         const nextCell = Array.from(nextRow.children).filter(cell => cell._column === nextCol)[0];
         e.preventDefault();
 
-        if (this.preserveEditMode && nextCell !== cell) {
+        if (this.keepEditorOpen && nextCell !== cell) {
           this._startEdit(nextCell, nextCol);
         } else {
           this._ensureScrolledToIndex(nextIdx);

--- a/src/vaadin-grid-pro-inline-editing-mixin.html
+++ b/src/vaadin-grid-pro-inline-editing-mixin.html
@@ -28,7 +28,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
          * will move focus to the editable cell in the next row
          * (Shift + Enter - same, but for previous row).
          */
-        allowEnterRowChange: {
+        enterNextRow: {
           type: Boolean,
           notify: true // FIXME(yuriy-fix): needed by Flow counterpart
         },
@@ -37,7 +37,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
          * When true, after moving to next or previous editable cell using
          * Tab / Shift+Tab, it will be focused in edit mode.
          *
-         * When `allowEnterRowChange` is true, pressing Enter will also
+         * When `enterNextRow` is true, pressing Enter will also
          * preserve edit mode, otherwise, it will have no effect.
          */
         preserveEditMode: {
@@ -259,7 +259,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         nextCol = column;
 
         // move up / down
-        if (this.allowEnterRowChange) {
+        if (this.enterNextRow) {
           nextIdx = e.shiftKey ? index - 1 : index + 1;
         }
       }

--- a/test/edit-column.html
+++ b/test/edit-column.html
@@ -218,8 +218,8 @@
             expect(spy).to.be.calledOnce;
           });
 
-          it('should focus editable cell on the next row in non-edit mode on Enter, if `allowEnterRowChange` is true', () => {
-            grid.allowEnterRowChange = true;
+          it('should focus editable cell on the next row in non-edit mode on Enter, if `enterNextRow` is true', () => {
+            grid.enterNextRow = true;
             const firstCell = getContainerCell(grid.$.items, 1, 0);
             enter(firstCell._content);
             input = getCellEditor(firstCell);
@@ -230,7 +230,7 @@
             expect(spy).to.be.calledOnce;
           });
 
-          it('should exit the edit mode for the cell on Enter, if `allowEnterRowChange` is false', () => {
+          it('should exit the edit mode for the cell on Enter, if `enterNextRow` is false', () => {
             const firstCell = getContainerCell(grid.$.items, 1, 0);
             dblclick(firstCell._content);
             input = getCellEditor(firstCell);
@@ -239,8 +239,8 @@
             expect(getCellEditor(firstCell)).to.be.not.ok;
           });
 
-          it('should focus editable cell on the previous row in non-edit mode on Shift Enter, if `allowEnterRowChange` is true', () => {
-            grid.allowEnterRowChange = true;
+          it('should focus editable cell on the previous row in non-edit mode on Shift Enter, if `enterNextRow` is true', () => {
+            grid.enterNextRow = true;
             const firstCell = getContainerCell(grid.$.items, 1, 0);
             enter(firstCell._content);
             input = getCellEditor(firstCell);
@@ -251,7 +251,7 @@
             expect(spy).to.be.calledOnce;
           });
 
-          it('should exit the edit mode for the cell on Shift Enter, if `allowEnterRowChange` is false', () => {
+          it('should exit the edit mode for the cell on Shift Enter, if `enterNextRow` is false', () => {
             const firstCell = getContainerCell(grid.$.items, 1, 0);
             dblclick(firstCell._content);
             input = getCellEditor(firstCell);
@@ -310,8 +310,8 @@
             expect(input).to.be.ok;
           });
 
-          it('should focus editable cell on the next row in edit mode on Enter, if `allowEnterRowChange` is true', () => {
-            grid.allowEnterRowChange = true;
+          it('should focus editable cell on the next row in edit mode on Enter, if `enterNextRow` is true', () => {
+            grid.enterNextRow = true;
             const firstCell = getContainerCell(grid.$.items, 1, 0);
             enter(firstCell._content);
             input = getCellEditor(firstCell);
@@ -322,7 +322,7 @@
             expect(input).to.be.ok;
           });
 
-          it('should exit the edit mode for the cell on Enter, if `allowEnterRowChange` is false', () => {
+          it('should exit the edit mode for the cell on Enter, if `enterNextRow` is false', () => {
             const firstCell = getContainerCell(grid.$.items, 1, 0);
             dblclick(firstCell._content);
             input = getCellEditor(firstCell);
@@ -331,8 +331,8 @@
             expect(getCellEditor(firstCell)).to.be.not.ok;
           });
 
-          it('should focus editable cell on the previous row in non-edit mode on Shift Enter, if `allowEnterRowChange` is true', () => {
-            grid.allowEnterRowChange = true;
+          it('should focus editable cell on the previous row in non-edit mode on Shift Enter, if `enterNextRow` is true', () => {
+            grid.enterNextRow = true;
             const firstCell = getContainerCell(grid.$.items, 1, 0);
             enter(firstCell._content);
             input = getCellEditor(firstCell);
@@ -343,7 +343,7 @@
             expect(input).to.be.ok;
           });
 
-          it('should exit the edit mode for the cell on Shift Enter, if `allowEnterRowChange` is false', () => {
+          it('should exit the edit mode for the cell on Shift Enter, if `enterNextRow` is false', () => {
             const firstCell = getContainerCell(grid.$.items, 1, 0);
             dblclick(firstCell._content);
             input = getCellEditor(firstCell);
@@ -870,8 +870,8 @@
             expect(cell._content.textContent).to.equal(value);
           });
 
-          it('should work with `preserveEditMode` and `allowEnterRowChange`', async() => {
-            grid.allowEnterRowChange = true;
+          it('should work with `preserveEditMode` and `enterNextRow`', async() => {
+            grid.enterNextRow = true;
             grid.preserveEditMode = true;
             const item = editor._overlay.querySelector('vaadin-item');
             enter(item);

--- a/test/edit-column.html
+++ b/test/edit-column.html
@@ -173,7 +173,7 @@
           flushGrid(grid);
         });
 
-        describe('when `preserveEditMode` is false', () => {
+        describe('when `keepEditorOpen` is false', () => {
           it('should focus cell next available for editing within a same row in non-edit mode on Tab', () => {
             const firstCell = getContainerCell(grid.$.items, 1, 0);
             dblclick(firstCell._content);
@@ -261,9 +261,9 @@
           });
         });
 
-        describe('when `preserveEditMode` is true', () => {
+        describe('when `keepEditorOpen` is true', () => {
           beforeEach(() => {
-            grid.preserveEditMode = true;
+            grid.keepEditorOpen = true;
           });
 
           it('should focus cell next available for editing within a same row in edit mode on Tab', () => {
@@ -870,9 +870,9 @@
             expect(cell._content.textContent).to.equal(value);
           });
 
-          it('should work with `preserveEditMode` and `enterNextRow`', async() => {
+          it('should work with `keepEditorOpen` and `enterNextRow`', async() => {
             grid.enterNextRow = true;
-            grid.preserveEditMode = true;
+            grid.keepEditorOpen = true;
             const item = editor._overlay.querySelector('vaadin-item');
             enter(item);
             item.click();


### PR DESCRIPTION
These names have been found rather confusing and a bit too long. 
Suggested alternatives seem to be slightly more self-descriptive.