### PR TITLE
Check for string boolean value [skip ci]

### DIFF
--- a/src/vaadin-grid-pro-edit-column.html
+++ b/src/vaadin-grid-pro-edit-column.html
@@ -277,6 +277,8 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
       _setEditorValue(editor, value) {
         const path = this.editorType === 'checkbox' ? 'checked' : this.editorValuePath;
+        // FIXME(yuriy): Required for the flow counterpart as it is passing the string value to webcomponent
+        value = (this.editorType === 'checkbox' && typeof value === 'string') ? value == 'true' : value;
         Polymer.Path.set(editor, path, value);
         editor.notifyPath && editor.notifyPath(path, value);
       }


### PR DESCRIPTION
Required for the flow counterpart as it is always passing stringified value to the webcomponent.