### PR TITLE
Add edit event

### DIFF
--- a/demo/grid-pro-edit-column-demos.html
+++ b/demo/grid-pro-edit-column-demos.html
@@ -192,7 +192,7 @@
     <h3>Custom Edit Mode Renderer</h3>
     <p>
       The custom editor component can be rendered for cell edit mode using <b><code>editModeRenderer</code></b>
-      function. Please make sure to render the component as a first child to the <code>root</code> provided as a first
+      function. Please make sure to render the component as a light DOM child to the <code>root</code> provided as a first
       argument for the renderer. See <a href="https://vaadin.com/components/vaadin-grid/html-examples/grid-basic-demos#defining-content-with-renderer-functions">&lt;vaadin-grid&gt; demo</a>
       for more details.
     </p>

--- a/demo/grid-pro-edit-column-demos.html
+++ b/demo/grid-pro-edit-column-demos.html
@@ -192,8 +192,9 @@
     <h3>Custom Edit Mode Renderer</h3>
     <p>
       The custom editor component can be rendered for cell edit mode using <b><code>editModeRenderer</code></b>
-      function. Please make sure to render the component as a light DOM child to the <code>root</code> provided as a first
-      argument for the renderer. See <a href="https://vaadin.com/components/vaadin-grid/html-examples/grid-basic-demos#defining-content-with-renderer-functions">&lt;vaadin-grid&gt; demo</a>
+      function. Please make sure to render the component that implements validate or/and checkValidity methods as a child
+      to the <code>root</code> provided as a first argument for the renderer.
+      See <a href="https://vaadin.com/components/vaadin-grid/html-examples/grid-basic-demos#defining-content-with-renderer-functions">&lt;vaadin-grid&gt; demo</a>
       for more details.
     </p>
     <p>

--- a/src/vaadin-grid-pro-edit-column.html
+++ b/src/vaadin-grid-pro-edit-column.html
@@ -206,8 +206,12 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
       _getEditorComponent(cell) {
         return this.editorType === 'custom' ?
-          cell._content.firstElementChild :
+          this._getCustomEditorComponent(cell) :
           cell._content.querySelector(this._getEditorTagName(cell));
+      }
+
+      _getCustomEditorComponent(cell) {
+        return Array.from(cell._content.querySelectorAll('*')).filter(node => node.validate || node.checkValidity)[0];
       }
 
       _getTagNameByType() {

--- a/src/vaadin-grid-pro-edit-column.html
+++ b/src/vaadin-grid-pro-edit-column.html
@@ -39,7 +39,8 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       static get properties() {
         return {
           /**
-           * Custom function for rendering the cell content in edit mode.
+           * Custom function for rendering the cell content in edit mode. The editor component
+           * attached to the `root` should implement `validate` or/and `checkValidity` methods.
            * Receives three arguments:
            *
            * - `root` The cell content DOM element. Append your editor component to it.

--- a/src/vaadin-grid-pro-inline-editing-mixin.html
+++ b/src/vaadin-grid-pro-inline-editing-mixin.html
@@ -248,6 +248,15 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       this.__edited = {cell, column, model};
       column._startCellEdit(cell, model);
 
+      this.dispatchEvent(new CustomEvent('cell-edit-started', {
+        detail: {
+          index: model.index,
+          item: model.item,
+          path: column.path
+        },
+        bubbles: true,
+        composed: true
+      }));
       this.addEventListener('item-property-changed', this.__boundItemPropertyChanged);
     }
 

--- a/src/vaadin-grid-pro-inline-editing-mixin.html
+++ b/src/vaadin-grid-pro-inline-editing-mixin.html
@@ -254,7 +254,6 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           item: model.item,
           path: column.path
         },
-        bubbles: true,
         composed: true
       }));
       this.addEventListener('item-property-changed', this.__boundItemPropertyChanged);

--- a/test/edit-column-renderer.html
+++ b/test/edit-column-renderer.html
@@ -52,6 +52,10 @@
               }
             };
           }
+
+          validate() {
+            // Placeholder for validation
+          }
         });
       });
     </script>


### PR DESCRIPTION
Editor input is now selected from the light DOM with the query selector instead of taking the first child. Needed for the case when component is rendered with `flow-component-renderer`.

`cell-edit-started` event is now dispatched when the cell enters edit-mode. Mostly will be used internally with Flow, so no public API for it.