### PR TITLE
Switch from keepEditorOpen to singleCellEdit

### DIFF
--- a/demo/grid-pro-edit-column-demos.html
+++ b/demo/grid-pro-edit-column-demos.html
@@ -68,8 +68,8 @@
         <vaadin-grid-pro>
           <vaadin-grid-column path="name.first" header="First Name"></vaadin-grid-column>
           <vaadin-grid-column path="name.last" header="Last name"></vaadin-grid-column>
-          <vaadin-grid-pro-edit-column path="name.title" header="Title (edit)" editor-type="select"></vaadin-grid-pro-edit-column>
           <vaadin-grid-pro-edit-column path="married" header="Married (edit)" editor-type="checkbox"></vaadin-grid-pro-edit-column>
+          <vaadin-grid-pro-edit-column path="name.title" header="Title (edit)" editor-type="select"></vaadin-grid-pro-edit-column>
         </vaadin-grid-pro>
         <script>
           window.addDemoReadyListener('#grid-pro-edit-column-demos-editor-type', function(document) {
@@ -106,20 +106,20 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Keep Editor Open</h3>
+    <h3>Single Cell Edit</h3>
     <p>
-      When <code>keepEditorOpen</code> is set on the grid element, focusing the next editable cell from keyboard will activate edit mode for it.
+      When <code>singleCellEdit</code> is set on the grid element, focusing the next editable cell from keyboard will exit the edit mode.
     </p>
-    <vaadin-demo-snippet id="grid-pro-edit-column-demos-keep-editor-open" when-defined="vaadin-grid-pro">
+    <vaadin-demo-snippet id="grid-pro-edit-column-demos-single-cell-edit" when-defined="vaadin-grid-pro">
       <template preserve-content>
-        <vaadin-grid-pro keep-editor-open>
+        <vaadin-grid-pro single-cell-edit>
           <vaadin-grid-pro-edit-column path="name.first" header="First name (edit)"></vaadin-grid-pro-edit-column>
           <vaadin-grid-column path="name.last" header="Last name (view)"></vaadin-grid-column>
-          <vaadin-grid-pro-edit-column path="name.title" header="Title (edit)" editor-type="select"></vaadin-grid-pro-edit-column>
           <vaadin-grid-pro-edit-column path="name.last" header="Last name (edit)"></vaadin-grid-pro-edit-column>
+          <vaadin-grid-pro-edit-column path="name.title" header="Title (edit)" editor-type="select"></vaadin-grid-pro-edit-column>
         </vaadin-grid-pro>
         <script>
-          window.addDemoReadyListener('#grid-pro-edit-column-demos-keep-editor-open', function(document) {
+          window.addDemoReadyListener('#grid-pro-edit-column-demos-single-cell-edit', function(document) {
             const grid = document.querySelector('vaadin-grid-pro');
             grid.items = Vaadin.GridDemo.getUsers();
             grid.querySelector('[path="name.title"]').editorOptions = ['mr', 'mrs', 'ms'];
@@ -138,7 +138,7 @@
     </ul>
     <vaadin-demo-snippet id="grid-pro-edit-column-demos-enter-next-row" when-defined="vaadin-grid-pro">
       <template preserve-content>
-        <vaadin-grid-pro enter-next-row keep-editor-open>
+        <vaadin-grid-pro enter-next-row>
           <vaadin-grid-pro-edit-column path="name.first" header="First name (edit)"></vaadin-grid-pro-edit-column>
           <vaadin-grid-column path="name.last" header="Last name (view)"></vaadin-grid-column>
           <vaadin-grid-pro-edit-column path="name.last" header="Last name (edit)"></vaadin-grid-pro-edit-column>

--- a/src/vaadin-grid-pro-edit-select.html
+++ b/src/vaadin-grid-pro-edit-select.html
@@ -82,7 +82,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
       __onKeydown(e) {
         if (e.keyCode === 9) {
-          this._grid.keepEditorOpen && this._grid._switchEditCell(e);
+          !this._grid.singleCellEdit && this._grid._switchEditCell(e);
         }
       }
 
@@ -126,7 +126,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           const enter = this._enterKeydown;
           if (enter && this._grid.enterNextRow) {
             this._grid._switchEditCell(enter);
-          } else if (!this._grid.keepEditorOpen) {
+          } else if (this._grid.singleCellEdit) {
             this._grid._stopEdit(false, true);
           }
         }

--- a/src/vaadin-grid-pro-inline-editing-mixin.html
+++ b/src/vaadin-grid-pro-inline-editing-mixin.html
@@ -35,12 +35,12 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
         /**
          * When true, after moving to next or previous editable cell using
-         * Tab / Shift+Tab, it will be focused in edit mode.
+         * Tab / Shift+Tab, it will be focused without edit mode.
          *
          * When `enterNextRow` is true, pressing Enter will also
          * preserve edit mode, otherwise, it will have no effect.
          */
-        keepEditorOpen: {
+        singleCellEdit: {
           type: Boolean,
           notify: true // FIXME(yuriy-fix): needed by Flow counterpart
         }
@@ -347,7 +347,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         const nextCell = Array.from(nextRow.children).filter(cell => cell._column === nextCol)[0];
         e.preventDefault();
 
-        if (this.keepEditorOpen && nextCell !== cell) {
+        if (!this.singleCellEdit && nextCell !== cell) {
           this._startEdit(nextCell, nextCol);
         } else {
           this._ensureScrolledToIndex(nextIdx);

--- a/test/edit-column-type.html
+++ b/test/edit-column-type.html
@@ -244,6 +244,7 @@
           });
 
           it('should update value and exit edit mode when item is selected', () => {
+            grid.singleCellEdit = true;
             const item = editor._overlay.querySelector('vaadin-item');
             const value = item.textContent;
             const spy = sinon.spy(cell, 'focus');
@@ -253,9 +254,8 @@
             expect(spy).to.be.calledOnce;
           });
 
-          it('should work with `keepEditorOpen` and `enterNextRow`', async() => {
+          it('should work with `enterNextRow`', async() => {
             grid.enterNextRow = true;
-            grid.keepEditorOpen = true;
             const item = editor._overlay.querySelector('vaadin-item');
             enter(item);
             item.click();

--- a/test/edit-column.html
+++ b/test/edit-column.html
@@ -95,7 +95,11 @@
           flushGrid(grid);
         });
 
-        describe('when `keepEditorOpen` is false', () => {
+        describe('when `singleCellEdit` is true', () => {
+          beforeEach(() => {
+            grid.singleCellEdit = true;
+          });
+
           it('should focus cell next available for editing within a same row in non-edit mode on Tab', () => {
             const firstCell = getContainerCell(grid.$.items, 1, 0);
             dblclick(firstCell._content);
@@ -183,11 +187,7 @@
           });
         });
 
-        describe('when `keepEditorOpen` is true', () => {
-          beforeEach(() => {
-            grid.keepEditorOpen = true;
-          });
-
+        describe('when `singleCellEdit` is false', () => {
           it('should focus cell next available for editing within a same row in edit mode on Tab', () => {
             const firstCell = getContainerCell(grid.$.items, 1, 0);
             dblclick(firstCell._content);
@@ -282,7 +282,6 @@
               grid.items = getItems();
               grid.querySelector('[path="title"]').editorOptions = ['mr', 'mrs', 'ms'];
               flushGrid(grid);
-              grid.keepEditorOpen = true;
               textCell = getContainerCell(grid.$.items, 1, 0);
               selectCell = getContainerCell(grid.$.items, 1, 1);
               checkboxCell = getContainerCell(grid.$.items, 1, 2);
@@ -328,6 +327,7 @@
         });
 
         it('should focus correct editable cell after column reordering', () => {
+          grid.singleCellEdit = true;
           grid.columnReorderingAllowed = true;
           const headerContent = [
             getContainerCell(grid.$.header, 0, 0)._content,
@@ -346,6 +346,7 @@
         });
 
         it('should focus correct editable cell when column is hidden', () => {
+          grid.singleCellEdit = true;
           const column = grid.querySelector('vaadin-grid-pro-edit-column');
           column.hidden = true;
 


### PR DESCRIPTION
Connected to https://github.com/vaadin/vaadin-grid-pro-flow/issues/36

Switch from `keepEditorOpen` to `singleCellEdit`, update the tests and demos.
In most cases have replaced `select` to be at the end for easier usage apart from those with `zip-code` cause they should be logically in the end.