### PR TITLE
Fix undefined column error when editor changes cell height

### DIFF
--- a/src/vaadin-grid-pro-inline-editing-mixin.html
+++ b/src/vaadin-grid-pro-inline-editing-mixin.html
@@ -70,7 +70,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       // Prevent click/selection on edit column
       this.$.table.addEventListener('click', e => {
         const column = this.getEventContext(e).column;
-        if (this._isEditColumn(column)) {
+        if (column && this._isEditColumn(column)) {
           e.preventDefault();
         }
       });


### PR DESCRIPTION
Fix #89. See the ticket for better description.

In this rare case, the first element in the click event's composed path
is tbody instead of the tr-element. For this reason, getEventContext()
can't find the targeted column. It's really unexpected that the composed
path doesn't start from the tr, even though the click clearly hits a
cell. Seems like a browser bug in this sense.