### PR TITLE
fix: stop editing before re-running renderer

### DIFF
--- a/src/vaadin-grid-pro-inline-editing-mixin.html
+++ b/src/vaadin-grid-pro-inline-editing-mixin.html
@@ -357,14 +357,13 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
     }
 
     _updateItem(row, item) {
-      super._updateItem(row, item);
-
       if (this.__edited) {
         const {cell, model} = this.__edited;
         if (cell.parentNode === row && model.item !== item) {
           this._stopEdit();
         }
       }
+      super._updateItem(row, item);
     }
 
     /**

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -20,6 +20,7 @@
     "getCellContent": false,
     "getCellEditor": false,
     "getContainerCell": false,
+    "getContainerCellContent": false,
     "getRows": false,
     "getRowCells": false
   }

--- a/test/edit-column-renderer.html
+++ b/test/edit-column-renderer.html
@@ -257,6 +257,23 @@
           expect(() => column._editModeTemplate = {}).to.throw(Error);
           expect(column._editModeTemplate).to.be.not.ok;
         });
+
+        it('should close editor and update value when scrolling edited cell out of view', () => {
+          grid.items = Array.apply(null, {length: 30}).map(_ => Object.assign({}, getItems()[0]));
+          cell = getContainerCell(grid.$.items, 0, 0);
+          column.editModeRenderer = function(root, owner, model) {
+            root.innerHTML = '<input>';
+          };
+
+          dblclick(cell._content);
+          getCellEditor(cell).value = 'Bar';
+          grid._scrollToIndex(29);
+          expect(getCellEditor(cell)).to.be.not.ok;
+          expect(grid.items[0].name).to.equal('Bar');
+
+          grid._scrollToIndex(0);
+          expect(getContainerCellContent(grid.$.items, 0, 0).innerHTML).to.equal('Bar');
+        });
       });
 
       describe('editorValuePath property', () => {


### PR DESCRIPTION
Fix #91

The problem was: When scrolling out of view, _updateItem is called,
which re-runs the renderer (in this case a custom edit mode renderer).
This would create a new renderer content without setting the model value
to it, right before the editor was closed, causing the empty value to be
saved to the model.