### PR TITLE
Fix focusout handling for editor components with overlay

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -46,7 +46,9 @@
     "webcomponentsjs": "^1.0.0",
     "web-component-tester": "^6.1.5",
     "vaadin-combo-box": "vaadin/vaadin-combo-box#^4.2.1",
-    "vaadin-demo-helpers": "vaadin/vaadin-demo-helpers#^2.2.0"
+    "vaadin-demo-helpers": "vaadin/vaadin-demo-helpers#^2.2.0",
+    "vaadin-date-picker": "vaadin/vaadin-date-picker#^4.0.0",
+    "vaadin-dialog": "vaadin/vaadin-dialog#^2.2.1"
   },
   "resolutions": {
     "vaadin-element-mixin": "^2.0.0"

--- a/src/vaadin-grid-pro-edit-column.html
+++ b/src/vaadin-grid-pro-edit-column.html
@@ -222,7 +222,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             type = 'checkbox';
             break;
           case 'select':
-            type = 'select-wrapper';
+            type = 'select';
             break;
           case 'text':
           default:
@@ -296,6 +296,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         this._grid.notifyResize();
         const editor = this._getEditorComponent(cell);
         editor.addEventListener('focusout', this._grid.__boundEditorFocusOut);
+        document.body.addEventListener('focusin', this._grid.__boundGlobalFocusIn);
         this._setEditorOptions(editor);
         this._setEditorValue(editor, Polymer.Path.get(model.item, this.path));
         editor._grid = this._grid;
@@ -328,6 +329,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           // avoid notify resize of editor removed due to scroll
           shouldResize = false;
         }
+        document.body.removeEventListener('focusin', this._grid.__boundGlobalFocusIn);
         this._removeEditor(cell, model);
         shouldResize && this._grid.notifyResize();
       }

--- a/src/vaadin-grid-pro-edit-select.html
+++ b/src/vaadin-grid-pro-edit-select.html
@@ -5,42 +5,32 @@ This program is available under Commercial Vaadin Add-On License 3.0 (CVALv3).
 See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete license.
 -->
 
-<link rel="import" href="../../polymer/polymer-element.html">
 <link rel="import" href="../../vaadin-select/src/vaadin-select.html">
 <link rel="import" href="../../vaadin-list-box/src/vaadin-list-box.html">
 <link rel="import" href="../../vaadin-item/src/vaadin-item.html">
 
-<dom-module id="vaadin-grid-pro-edit-select-wrapper">
-  <template>
-    <vaadin-grid-pro-edit-select
-      id="selectEditor"
-      value="{{value}}"
-      theme="grid-pro-editor"
-      on-keydown="_onSelectKeydown"
-      on-focusout="_onSelectFocusout"
-    ></vaadin-grid-pro-edit-select>
-  </template>
-</dom-module>
-
 <script>
   (function() {
     /**
-     * The cell editor select element wrapper.
+     * The cell editor select element.
+     *
+     * ### Styling
+     *
+     * See [`<vaadin-select>` documentation](https://github.com/vaadin/vaadin-select/blob/master/src/vaadin-select.html)
+     * for `<vaadin-grid-pro-edit-select>` parts.
+     *
+     * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
      *
      * @memberof Vaadin
+     * @extends Vaadin.SelectElement
      */
-    class GridProEditSelectWrapperElement extends Polymer.Element {
+    class GridProEditSelectElement extends Vaadin.SelectElement {
       static get is() {
-        return 'vaadin-grid-pro-edit-select-wrapper';
+        return 'vaadin-grid-pro-edit-select';
       }
 
       static get properties() {
         return {
-          value: {
-            type: String,
-            observer: '_valueChanged'
-          },
-
           options: {
             type: Array,
             value: () => []
@@ -52,62 +42,28 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
           _initialized: {
             type: Boolean
-          },
-
-          _select: {
-            type: Object
-          },
-
-          _overlay: {
-            type: Object
           }
         };
       }
 
-      connectedCallback() {
-        super.connectedCallback();
-        this.__boundOnKeydown = this.__onKeydown.bind(this);
-        this._select._overlayElement.addEventListener('keydown', this.__boundOnKeydown);
-      }
-
-      disconnectedCallback() {
-        super.disconnectedCallback();
-        this._select._overlayElement.removeEventListener('keydown', this.__boundOnKeydown);
+      static get observers() {
+        return [
+          '_optionsChanged(options)'
+        ];
       }
 
       ready() {
         super.ready();
-        this._select = this.$.selectEditor;
+
+        this.setAttribute('theme', 'grid-pro-editor');
+
+        this.__boundOnKeyDown = this.__onOverlayKeyDown.bind(this);
+        this._overlayElement.addEventListener('keydown', this.__boundOnKeyDown);
       }
 
-      __onKeydown(e) {
-        if (e.keyCode === 9) {
-          !this._grid.singleCellEdit && this._grid._switchEditCell(e);
-        }
-      }
+      _onKeyDown(e) {
+        super._onKeyDown(e);
 
-      static get observers() {
-        return [
-          '_optionsChanged(_select, options)'
-        ];
-      }
-
-      focus() {
-        this.$.selectEditor.focus();
-      }
-
-      get select() {
-        return this.$.selectEditor;
-      }
-
-      _onSelectFocusout(e) {
-        // Do not exit edit mode when opening overlay
-        if (this._overlay && this._overlay.contains(e.relatedTarget)) {
-          e.stopPropagation();
-        }
-      }
-
-      _onSelectKeydown(e) {
         if (this.options.length === 0 && /^(ArrowDown|Down|ArrowUp|Up|Enter|SpaceBar| )$/.test(e.key)) {
           console.warn('Missing "editorOptions" for <vaadin-grid-pro-edit-column> select editor!');
         }
@@ -117,7 +73,15 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         }
       }
 
+      __onOverlayKeyDown(e) {
+        if (e.keyCode === 9) {
+          !this._grid.singleCellEdit && this._grid._switchEditCell(e);
+        }
+      }
+
       _valueChanged(value, oldValue) {
+        super._valueChanged(value, oldValue);
+
         // select is first created without a value
         if (value === '' && oldValue === undefined) {
           return;
@@ -128,13 +92,15 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             this._grid._switchEditCell(enter);
           } else if (this._grid.singleCellEdit) {
             this._grid._stopEdit(false, true);
+          } else {
+            this.focus();
           }
         }
       }
 
-      _optionsChanged(select, options) {
-        if (select && options && options.length) {
-          select.renderer = root => {
+      _optionsChanged(options) {
+        if (options && options.length) {
+          this.renderer = root => {
             if (root.firstChild) {
               return;
             }
@@ -159,41 +125,18 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             window.ShadyDOM && window.ShadyDOM.flush();
           };
 
-          this._overlay = select.shadowRoot.querySelector('vaadin-select-overlay');
-
-          this._overlay.addEventListener('vaadin-overlay-outside-click', e => {
+          this._overlayElement.addEventListener('vaadin-overlay-outside-click', e => {
             this._grid._stopEdit();
           });
 
           // FIXME(web-padawan): _updateValueSlot() in `vaadin-select` resets opened to false
           // see https://github.com/vaadin/vaadin-list-mixin/issues/49
           setTimeout(() => {
-            select.opened = true;
+            this.opened = true;
             // any value change after first open will stop edit
             this._initialized = true;
           });
         }
-      }
-    }
-
-    customElements.define(GridProEditSelectWrapperElement.is, GridProEditSelectWrapperElement);
-
-    /**
-     * The cell editor select element.
-     *
-     * ### Styling
-     *
-     * See [`<vaadin-select>` documentation](https://github.com/vaadin/vaadin-select/blob/master/src/vaadin-select.html)
-     * for `<vaadin-grid-pro-edit-select>` parts.
-     *
-     * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
-     *
-     * @memberof Vaadin
-     * @extends Vaadin.SelectElement
-     */
-    class GridProEditSelectElement extends Vaadin.SelectElement {
-      static get is() {
-        return 'vaadin-grid-pro-edit-select';
       }
     }
 

--- a/src/vaadin-grid-pro-inline-editing-mixin.html
+++ b/src/vaadin-grid-pro-inline-editing-mixin.html
@@ -51,6 +51,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       super();
       this.__boundItemPropertyChanged = this._onItemPropertyChanged.bind(this);
       this.__boundEditorFocusOut = this._onEditorFocusOut.bind(this);
+      this.__boundGlobalFocusIn = this._onGlobalFocusIn.bind(this);
 
       this._addEditColumnListener('mousedown', e => {
         // prevent grid from resetting navigating state
@@ -236,6 +237,21 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         this._debouncerStopEdit,
         Polymer.Async.timeOut.after(200),
         this._stopEdit.bind(this));
+    }
+
+    _onGlobalFocusIn(e) {
+      const edited = this.__edited;
+      if (edited) {
+        const editor = edited.column._getEditorComponent(edited.cell);
+
+        // detect focus moving to e.g. vaadin-select-overlay
+        const overlay = Array.from(e.composedPath())
+          .filter(node => node.nodeType === Node.ELEMENT_NODE && /vaadin-(?!dialog).*-overlay/i.test(node.localName))[0];
+
+        if (overlay && overlay.__dataHost === editor) {
+          this._cancelStopEdit();
+        }
+      }
     }
 
     _startEdit(cell, column) {

--- a/test/edit-column-overlay.html
+++ b/test/edit-column-overlay.html
@@ -1,0 +1,106 @@
+<!doctype html>
+
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>edit-column-overlay test</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../iron-test-helpers/mock-interactions.js"></script>
+  <link rel="import" href="../../test-fixture/test-fixture.html">
+
+  <link rel="import" href="helpers.html">
+  <link rel="import" href="not-animated-styles.html">
+  <link rel="import" href="../vaadin-grid-pro.html">
+  <link rel="import" href="../vaadin-grid-pro-edit-column.html">
+
+  <link rel="import" href="../../vaadin-date-picker/vaadin-date-picker.html">
+  <link rel="import" href="../../vaadin-dialog/vaadin-dialog.html">
+</head>
+
+<body>
+  <test-fixture id="default">
+    <template>
+      <vaadin-dialog opened>
+        <template>
+          <vaadin-grid-pro id="grid">
+            <vaadin-grid-column path="name" header="First Name"></vaadin-grid-column>
+            <vaadin-grid-pro-edit-column path="custom" header="Custom"></vaadin-grid-pro-edit-column>
+          </vaadin-grid-pro>
+          <vaadin-text-field></vaadin-text-field>
+        </template>
+      </vaadin-dialog>
+    </template>
+  </test-fixture>
+
+  <script>
+    function getItems() {
+      return [
+        {name: 'foo', custom: 'custom1	2019-01-01'},
+        {name: 'bar', custom: 'custom2	2019-01-01'},
+        {name: 'baz', custom: 'custom3	2019-01-01'}
+      ];
+    }
+
+    function enter(target) {
+      MockInteractions.keyDownOn(target, 13, [], 'Enter');
+    }
+
+    describe('default', () => {
+      let dialog, grid, dateCell;
+
+      beforeEach(() => {
+        dialog = fixture('default');
+        grid = dialog.$.overlay.querySelector('vaadin-grid-pro');
+        grid.items = getItems();
+        grid.style.width = '100px'; // column default min width is 100px
+        flushGrid(grid);
+
+        dateCell = getContainerCell(grid.$.items, 0, 1);
+
+        grid.querySelector('[path="custom"]').editModeRenderer = function(root, column, rowData) {
+          root.innerHTML = '';
+          const datePicker = document.createElement('vaadin-date-picker');
+          root.appendChild(datePicker);
+        };
+      });
+
+      it('should not stop editing when focusing input related overlay', () => {
+        enter(dateCell);
+        const datePicker = getCellEditor(dateCell);
+        datePicker.click();
+
+        // Mimic clicking the date-icker overlay
+        const focusout = new CustomEvent('focusout', {bubbles: true, composed: true});
+        datePicker.dispatchEvent(focusout);
+
+        const focusin = new CustomEvent('focusin', {bubbles: true, composed: true});
+        datePicker.$.overlay.dispatchEvent(focusin);
+        grid._debouncerStopEdit && grid._debouncerStopEdit.flush();
+
+        expect(getCellEditor(dateCell)).to.be.ok;
+      });
+
+      it('should stop editing when focusing overlay containing grid', () => {
+        enter(dateCell);
+        const datePicker = getCellEditor(dateCell);
+
+        // Mimic clicking the dialog overlay
+        const evt = new CustomEvent('focusout', {bubbles: true, composed: true});
+        datePicker.dispatchEvent(evt);
+
+        const focusin = new CustomEvent('focusin', {bubbles: true, composed: true});
+        dialog.$.overlay.dispatchEvent(focusin);
+        grid._debouncerStopEdit && grid._debouncerStopEdit.flush();
+
+        expect(getCellEditor(dateCell)).to.be.not.ok;
+      });
+    });
+  </script>
+
+</body>
+
+</html>

--- a/test/edit-column-type.html
+++ b/test/edit-column-type.html
@@ -117,7 +117,7 @@
           cell = getContainerCell(grid.$.items, 0, 1);
           dblclick(cell._content);
           editor = column._getEditorComponent(cell);
-          expect(editor._select instanceof Vaadin.SelectElement).to.equal(true);
+          expect(editor instanceof Vaadin.SelectElement).to.equal(true);
         });
 
         it('should render the checkbox to cell with text checkbox type specified', () => {
@@ -165,7 +165,7 @@
       });
 
       describe('select', () => {
-        let grid, cell, column, editor, select;
+        let grid, cell, column, editor;
 
         const nextRender = (elem) => {
           return new Promise(resolve => {
@@ -196,56 +196,56 @@
             cell = getContainerCell(grid.$.items, 0, 1);
             enter(cell._content);
             editor = getCellEditor(cell);
-            select = editor._select;
-            onceOpened(select).then(() => done());
+            onceOpened(editor).then(() => done());
           });
 
           it('should render the opened select to cell in edit mode', () => {
-            expect(select instanceof Vaadin.SelectElement).to.equal(true);
-            expect(select.value).to.be.equal('mrs');
-            expect(select.opened).to.equal(true);
+            expect(editor instanceof Vaadin.SelectElement).to.equal(true);
+            expect(editor.value).to.be.equal('mrs');
+            expect(editor.opened).to.equal(true);
           });
 
           it('should open the select and stop focusout on editor click', async() => {
-            select.opened = false;
-            select.focusElement.click();
-            const evt = new CustomEvent('focusout', {bubbles: true, composed: true});
-            evt.relatedTarget = editor._overlay.querySelector('vaadin-item');
-            select.dispatchEvent(evt);
+            editor.opened = false;
+            editor.focusElement.click();
+            const focusout = new CustomEvent('focusout', {bubbles: true, composed: true});
+            editor.dispatchEvent(focusout);
+            const focusin = new CustomEvent('focusin', {bubbles: true, composed: true});
+            editor._overlayElement.querySelector('vaadin-item').dispatchEvent(focusin);
             grid._flushStopEdit();
-            await nextRender(select._menuElement);
-            expect(select.opened).to.equal(true);
+            await nextRender(editor._menuElement);
+            expect(editor.opened).to.equal(true);
           });
 
           it('should close the select and exit edit mode on outside click', () => {
             document.body.click();
-            expect(select.opened).to.equal(false);
+            expect(editor.opened).to.equal(false);
           });
 
           it('should open the select on space key', async() => {
-            select.opened = false;
-            space(select.focusElement);
-            await nextRender(select._menuElement);
-            expect(select.opened).to.equal(true);
+            editor.opened = false;
+            space(editor.focusElement);
+            await nextRender(editor._menuElement);
+            expect(editor.opened).to.equal(true);
           });
 
           it('should open the select on arrow down key', async() => {
-            select.opened = false;
-            down(select.focusElement);
-            await nextRender(select._menuElement);
-            expect(select.opened).to.equal(true);
+            editor.opened = false;
+            down(editor.focusElement);
+            await nextRender(editor._menuElement);
+            expect(editor.opened).to.equal(true);
           });
 
           it('should open the select on arrow up key', async() => {
-            select.opened = false;
-            up(select.focusElement);
-            await nextRender(select._menuElement);
-            expect(select.opened).to.equal(true);
+            editor.opened = false;
+            up(editor.focusElement);
+            await nextRender(editor._menuElement);
+            expect(editor.opened).to.equal(true);
           });
 
           it('should update value and exit edit mode when item is selected', () => {
             grid.singleCellEdit = true;
-            const item = editor._overlay.querySelector('vaadin-item');
+            const item = editor._overlayElement.querySelector('vaadin-item');
             const value = item.textContent;
             const spy = sinon.spy(cell, 'focus');
             item.click();
@@ -256,7 +256,7 @@
 
           it('should work with `enterNextRow`', async() => {
             grid.enterNextRow = true;
-            const item = editor._overlay.querySelector('vaadin-item');
+            const item = editor._overlayElement.querySelector('vaadin-item');
             enter(item);
             item.click();
             expect(column._getEditorComponent(cell)).to.not.be.ok;
@@ -276,48 +276,46 @@
             cell = getContainerCell(grid.$.items, 0, 1);
             enter(cell._content);
             editor = getCellEditor(cell);
-            select = editor._select;
-            Polymer.RenderStatus.afterNextRender(select, () => done());
+            Polymer.RenderStatus.afterNextRender(editor, () => done());
           });
 
           it('should render the closed select to cell in edit mode', () => {
-            expect(select instanceof Vaadin.SelectElement).to.equal(true);
-            expect(select.value).to.be.equal('mrs');
-            expect(select.opened).to.equal(false);
+            expect(editor instanceof Vaadin.SelectElement).to.equal(true);
+            expect(editor.value).to.be.equal('mrs');
+            expect(editor.opened).to.equal(false);
           });
 
           it('should not throw when moving focus out of the select', () => {
             const evt = new CustomEvent('focusout', {bubbles: true, composed: true});
-            evt.relatedTarget = document.body;
-            select.dispatchEvent(evt);
+            editor.dispatchEvent(evt);
             grid._debouncerStopEdit && grid._debouncerStopEdit.flush();
             expect(column._getEditorComponent(cell)).to.not.be.ok;
           });
 
           it('should warn about missing options on enter key', async() => {
             sinon.stub(console, 'warn');
-            enter(select.focusElement);
+            enter(editor.focusElement);
             expect(console.warn.called).to.be.true;
             console.warn.restore();
           });
 
           it('should warn about missing options on space key', async() => {
             sinon.stub(console, 'warn');
-            space(select.focusElement);
+            space(editor.focusElement);
             expect(console.warn.called).to.be.true;
             console.warn.restore();
           });
 
           it('should warn about missing options on arrow down key', async() => {
             sinon.stub(console, 'warn');
-            down(select.focusElement);
+            down(editor.focusElement);
             expect(console.warn.called).to.be.true;
             console.warn.restore();
           });
 
           it('should warn about missing options on arrow up key', async() => {
             sinon.stub(console, 'warn');
-            up(select.focusElement);
+            up(editor.focusElement);
             expect(console.warn.called).to.be.true;
             console.warn.restore();
           });

--- a/test/edit-column.html
+++ b/test/edit-column.html
@@ -292,7 +292,7 @@
               input = getCellEditor(textCell);
               tab(input);
 
-              selectOverlay = getCellEditor(selectCell)._select._overlayElement;
+              selectOverlay = getCellEditor(selectCell)._overlayElement;
               selectOverlay.addEventListener('vaadin-overlay-open', e => {
                 tab(selectOverlay);
                 input = getCellEditor(checkboxCell);
@@ -306,7 +306,7 @@
               input = getCellEditor(checkboxCell);
               shiftTab(input);
 
-              selectOverlay = getCellEditor(selectCell)._select._overlayElement;
+              selectOverlay = getCellEditor(selectCell)._overlayElement;
               selectOverlay.addEventListener('vaadin-overlay-open', e => {
                 shiftTab(selectOverlay);
                 input = getCellEditor(textCell);

--- a/test/test-suites.js
+++ b/test/test-suites.js
@@ -3,5 +3,6 @@ window.GridProElementSuites = [
   'edit-column.html',
   'edit-column-renderer.html',
   'edit-column-template.html',
-  'edit-column-type.html'
+  'edit-column-type.html',
+  'edit-column-overlay.html'
 ];


### PR DESCRIPTION
Fixes #94 

The PR includes the refactoring for `select` editor type which shouldn't break anything.

I came up with an idea how to get rid of the select wrapper, and it is needed for a more common workaround for `focusout` event (due to lack of `relatedTarget` on iOS 10).