### PR TITLE
Do not stop editing when interacting within the same cell.

### DIFF
--- a/src/vaadin-grid-pro-edit-column.html
+++ b/src/vaadin-grid-pro-edit-column.html
@@ -128,8 +128,8 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       }
 
       /** @protected */
-      connectedCallback() {
-        super.connectedCallback();
+      ready() {
+        super.ready();
 
         this._editTemplateObserver.flush();
       }
@@ -296,6 +296,8 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         this._grid.notifyResize();
         const editor = this._getEditorComponent(cell);
         editor.addEventListener('focusout', this._grid.__boundEditorFocusOut);
+        editor.addEventListener('focusin', this._grid.__boundEditorFocusIn);
+        editor.addEventListener('internal-tabbing', this._grid.__boundCancelCellSwitch);
         document.body.addEventListener('focusin', this._grid.__boundGlobalFocusIn);
         this._setEditorOptions(editor);
         this._setEditorValue(editor, Polymer.Path.get(model.item, this.path));
@@ -325,6 +327,8 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         let shouldResize = true;
         if (editor) {
           editor.removeEventListener('focusout', this._grid.__boundEditorFocusOut);
+          editor.removeEventListener('focusin', this._grid.__boundEditorFocusIn);
+          editor.removeEventListener('internal-tabbing', this._grid.__boundCancelCellSwitch);
         } else {
           // avoid notify resize of editor removed due to scroll
           shouldResize = false;

--- a/src/vaadin-grid-pro-edit-column.html
+++ b/src/vaadin-grid-pro-edit-column.html
@@ -297,7 +297,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         const editor = this._getEditorComponent(cell);
         editor.addEventListener('focusout', this._grid.__boundEditorFocusOut);
         editor.addEventListener('focusin', this._grid.__boundEditorFocusIn);
-        editor.addEventListener('internal-tabbing', this._grid.__boundCancelCellSwitch);
+        editor.addEventListener('internal-tab', this._grid.__boundCancelCellSwitch);
         document.body.addEventListener('focusin', this._grid.__boundGlobalFocusIn);
         this._setEditorOptions(editor);
         this._setEditorValue(editor, Polymer.Path.get(model.item, this.path));
@@ -328,7 +328,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         if (editor) {
           editor.removeEventListener('focusout', this._grid.__boundEditorFocusOut);
           editor.removeEventListener('focusin', this._grid.__boundEditorFocusIn);
-          editor.removeEventListener('internal-tabbing', this._grid.__boundCancelCellSwitch);
+          editor.removeEventListener('internal-tab', this._grid.__boundCancelCellSwitch);
         } else {
           // avoid notify resize of editor removed due to scroll
           shouldResize = false;

--- a/src/vaadin-grid-pro-inline-editing-mixin.html
+++ b/src/vaadin-grid-pro-inline-editing-mixin.html
@@ -51,6 +51,8 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       super();
       this.__boundItemPropertyChanged = this._onItemPropertyChanged.bind(this);
       this.__boundEditorFocusOut = this._onEditorFocusOut.bind(this);
+      this.__boundEditorFocusIn = this._onEditorFocusIn.bind(this);
+      this.__boundCancelCellSwitch = this._setCancelCellSwitch.bind(this);
       this.__boundGlobalFocusIn = this._onGlobalFocusIn.bind(this);
 
       this._addEditColumnListener('mousedown', e => {
@@ -239,16 +241,18 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         this._stopEdit.bind(this));
     }
 
+    _onEditorFocusIn(e) {
+      this._cancelStopEdit();
+    }
+
     _onGlobalFocusIn(e) {
       const edited = this.__edited;
       if (edited) {
-        const editor = edited.column._getEditorComponent(edited.cell);
-
         // detect focus moving to e.g. vaadin-select-overlay
         const overlay = Array.from(e.composedPath())
           .filter(node => node.nodeType === Node.ELEMENT_NODE && /vaadin-(?!dialog).*-overlay/i.test(node.localName))[0];
 
-        if (overlay && overlay.__dataHost === editor) {
+        if (overlay) {
           this._cancelStopEdit();
         }
       }
@@ -312,7 +316,16 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       }
     }
 
+    _setCancelCellSwitch() {
+      this.__cancelCellSwitch = true;
+    }
+
     _switchEditCell(e) {
+      if (this.__cancelCellSwitch) {
+        this.__cancelCellSwitch = false;
+        return;
+      }
+
       this._cancelStopEdit();
 
       const cols = this._getEditColumns();

--- a/src/vaadin-grid-pro-inline-editing-mixin.html
+++ b/src/vaadin-grid-pro-inline-editing-mixin.html
@@ -250,9 +250,10 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       if (edited) {
         // detect focus moving to e.g. vaadin-select-overlay
         const overlay = Array.from(e.composedPath())
-          .filter(node => node.nodeType === Node.ELEMENT_NODE && /vaadin-(?!dialog).*-overlay/i.test(node.localName))[0];
+          .filter(node => node.nodeType === Node.ELEMENT_NODE && /^vaadin-(?!dialog).*-overlay$/i.test(node.localName))[0];
 
         if (overlay) {
+          overlay.addEventListener('vaadin-overlay-outside-click', this.__boundEditorFocusOut);
           this._cancelStopEdit();
         }
       }
@@ -318,11 +319,12 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
     _setCancelCellSwitch() {
       this.__cancelCellSwitch = true;
+      window.requestAnimationFrame(() => this.__cancelCellSwitch = false);
     }
 
     _switchEditCell(e) {
-      if (this.__cancelCellSwitch) {
-        this.__cancelCellSwitch = false;
+      if (this.__cancelCellSwitch ||
+          e.defaultPrevented && e.keyCode === 9) {
         return;
       }
 

--- a/test/edit-column-overlay.html
+++ b/test/edit-column-overlay.html
@@ -70,6 +70,15 @@
       MockInteractions.keyDownOn(target, 13, [], 'Enter');
     }
 
+    // Mimic clicking the overlay
+    function clickOverlay(element) {
+      const focusout = new CustomEvent('focusout', {bubbles: true, composed: true});
+      element.dispatchEvent(focusout);
+
+      const focusin = new CustomEvent('focusin', {bubbles: true, composed: true});
+      element.$.overlay.dispatchEvent(focusin);
+    }
+
     ['default', 'template'].forEach(type => {
       describe(type, () => {
         let dialog, grid, dateCell;
@@ -99,15 +108,22 @@
           const datePicker = getCellEditor(dateCell).querySelector('vaadin-date-picker');
           datePicker.click();
 
-          // Mimic clicking the date-icker overlay
-          const focusout = new CustomEvent('focusout', {bubbles: true, composed: true});
-          datePicker.dispatchEvent(focusout);
-
-          const focusin = new CustomEvent('focusin', {bubbles: true, composed: true});
-          datePicker.$.overlay.dispatchEvent(focusin);
+          clickOverlay(datePicker);
           grid._debouncerStopEdit && grid._debouncerStopEdit.flush();
 
           expect(getCellEditor(dateCell)).to.be.ok;
+        });
+
+        it('should stop editing on outside click from input related overlay', () => {
+          enter(dateCell);
+          const datePicker = getCellEditor(dateCell).querySelector('vaadin-date-picker');
+          datePicker.click();
+
+          clickOverlay(datePicker);
+          document.body.click();
+          grid._debouncerStopEdit && grid._debouncerStopEdit.flush();
+
+          expect(getCellEditor(dateCell)).not.to.be.ok;
         });
 
         it('should stop editing when focusing overlay containing grid', () => {

--- a/test/edit-column-overlay.html
+++ b/test/edit-column-overlay.html
@@ -28,7 +28,28 @@
         <template>
           <vaadin-grid-pro id="grid">
             <vaadin-grid-column path="name" header="First Name"></vaadin-grid-column>
-            <vaadin-grid-pro-edit-column path="custom" header="Custom"></vaadin-grid-pro-edit-column>
+            <vaadin-grid-pro-edit-column path="date" header="Date"></vaadin-grid-pro-edit-column>
+          </vaadin-grid-pro>
+          <vaadin-text-field></vaadin-text-field>
+        </template>
+      </vaadin-dialog>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="template">
+    <template>
+      <vaadin-dialog opened>
+        <template>
+          <vaadin-grid-pro id="grid">
+            <vaadin-grid-column path="name" header="First Name"></vaadin-grid-column>
+            <vaadin-grid-pro-edit-column path="date" header="Date">
+              <template class="editor">
+                <!-- Div can be any component that is wrapping the element with the overlay, e.g. vaadin-custom-field -->
+                <div>
+                  <vaadin-date-picker></vaadin-date-picker>
+                </div>
+              </template>
+            </vaadin-grid-pro-edit-column>
           </vaadin-grid-pro>
           <vaadin-text-field></vaadin-text-field>
         </template>
@@ -39,9 +60,9 @@
   <script>
     function getItems() {
       return [
-        {name: 'foo', custom: 'custom1	2019-01-01'},
-        {name: 'bar', custom: 'custom2	2019-01-01'},
-        {name: 'baz', custom: 'custom3	2019-01-01'}
+        {name: 'foo', date: '2019-01-01'},
+        {name: 'bar', date: '2019-01-01'},
+        {name: 'baz', date: '2019-01-01'}
       ];
     }
 
@@ -49,54 +70,60 @@
       MockInteractions.keyDownOn(target, 13, [], 'Enter');
     }
 
-    describe('default', () => {
-      let dialog, grid, dateCell;
+    ['default', 'template'].forEach(type => {
+      describe(type, () => {
+        let dialog, grid, dateCell;
 
-      beforeEach(() => {
-        dialog = fixture('default');
-        grid = dialog.$.overlay.querySelector('vaadin-grid-pro');
-        grid.items = getItems();
-        grid.style.width = '100px'; // column default min width is 100px
-        flushGrid(grid);
+        beforeEach(() => {
+          dialog = fixture(type);
+          grid = dialog.$.overlay.querySelector('vaadin-grid-pro');
+          grid.items = getItems();
+          grid.style.width = '100px'; // column default min width is 100px
+          flushGrid(grid);
 
-        dateCell = getContainerCell(grid.$.items, 0, 1);
+          dateCell = getContainerCell(grid.$.items, 0, 1);
 
-        grid.querySelector('[path="custom"]').editModeRenderer = function(root, column, rowData) {
-          root.innerHTML = '';
-          const datePicker = document.createElement('vaadin-date-picker');
-          root.appendChild(datePicker);
-        };
-      });
+          if (type === 'default') {
+            grid.querySelector('[path="date"]').editModeRenderer = function(root, column, rowData) {
+              root.innerHTML = '';
+              const inputWrapper = document.createElement('div');
+              const datePicker = document.createElement('vaadin-date-picker');
+              inputWrapper.appendChild(datePicker);
+              root.appendChild(inputWrapper);
+            };
+          }
+        });
 
-      it('should not stop editing when focusing input related overlay', () => {
-        enter(dateCell);
-        const datePicker = getCellEditor(dateCell);
-        datePicker.click();
+        it('should not stop editing when focusing input related overlay', () => {
+          enter(dateCell);
+          const datePicker = getCellEditor(dateCell).querySelector('vaadin-date-picker');
+          datePicker.click();
 
-        // Mimic clicking the date-icker overlay
-        const focusout = new CustomEvent('focusout', {bubbles: true, composed: true});
-        datePicker.dispatchEvent(focusout);
+          // Mimic clicking the date-icker overlay
+          const focusout = new CustomEvent('focusout', {bubbles: true, composed: true});
+          datePicker.dispatchEvent(focusout);
 
-        const focusin = new CustomEvent('focusin', {bubbles: true, composed: true});
-        datePicker.$.overlay.dispatchEvent(focusin);
-        grid._debouncerStopEdit && grid._debouncerStopEdit.flush();
+          const focusin = new CustomEvent('focusin', {bubbles: true, composed: true});
+          datePicker.$.overlay.dispatchEvent(focusin);
+          grid._debouncerStopEdit && grid._debouncerStopEdit.flush();
 
-        expect(getCellEditor(dateCell)).to.be.ok;
-      });
+          expect(getCellEditor(dateCell)).to.be.ok;
+        });
 
-      it('should stop editing when focusing overlay containing grid', () => {
-        enter(dateCell);
-        const datePicker = getCellEditor(dateCell);
+        it('should stop editing when focusing overlay containing grid', () => {
+          enter(dateCell);
+          const datePicker = getCellEditor(dateCell).querySelector('vaadin-date-picker');
 
-        // Mimic clicking the dialog overlay
-        const evt = new CustomEvent('focusout', {bubbles: true, composed: true});
-        datePicker.dispatchEvent(evt);
+          // Mimic clicking the dialog overlay
+          const evt = new CustomEvent('focusout', {bubbles: true, composed: true});
+          datePicker.dispatchEvent(evt);
 
-        const focusin = new CustomEvent('focusin', {bubbles: true, composed: true});
-        dialog.$.overlay.dispatchEvent(focusin);
-        grid._debouncerStopEdit && grid._debouncerStopEdit.flush();
+          const focusin = new CustomEvent('focusin', {bubbles: true, composed: true});
+          dialog.$.overlay.dispatchEvent(focusin);
+          grid._debouncerStopEdit && grid._debouncerStopEdit.flush();
 
-        expect(getCellEditor(dateCell)).to.be.not.ok;
+          expect(getCellEditor(dateCell)).to.be.not.ok;
+        });
       });
     });
   </script>

--- a/test/edit-column.html
+++ b/test/edit-column.html
@@ -44,6 +44,24 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="custom">
+    <template>
+      <vaadin-grid-pro>
+        <vaadin-grid-pro-edit-column path="name"></vaadin-grid-pro-edit-column>
+        <vaadin-grid-pro-edit-column path="custom">
+          <template class="editor">
+            <div>
+              <input type="text">
+              <input type="text">
+            </div>
+          </template>
+        </vaadin-grid-pro-edit-column>
+        <vaadin-grid-pro-edit-column path="age"></vaadin-grid-pro-edit-column>
+        <vaadin-grid-column path="name"></vaadin-grid-column>
+      </vaadin-grid-pro>
+    </template>
+  </test-fixture>
+
   <script>
     const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
 
@@ -358,6 +376,31 @@
           const spy = sinon.spy(secondCell, 'focus');
           tab(input);
           expect(spy).to.be.calledOnce;
+        });
+      });
+
+      describe('wrapped fields in custom editor', () => {
+        let grid, inputWrapper;
+
+        beforeEach(() => {
+          grid = fixture('custom');
+          grid.items = getItems();
+          flushGrid(grid);
+        });
+
+        it('should not stop editing when focusing the input within the same cell', () => {
+          const customCell = getContainerCell(grid.$.items, 1, 1);
+          dblclick(customCell._content);
+          inputWrapper = getCellEditor(customCell);
+          const inputs = inputWrapper.querySelectorAll('input');
+
+          expect(inputWrapper).to.be.ok;
+
+          inputs[0].dispatchEvent(new CustomEvent('focusout', {bubbles: true, composed: true}));
+          inputs[1].dispatchEvent(new CustomEvent('focusin', {bubbles: true, composed: true}));
+          grid._debouncerStopEdit && grid._debouncerStopEdit.flush();
+
+          expect(getCellEditor(customCell)).to.be.ok;
         });
       });
 

--- a/test/edit-column.html
+++ b/test/edit-column.html
@@ -217,6 +217,40 @@
             expect(input).to.be.ok;
           });
 
+          it('should not focus cell next available for editing on Tab if default prevented for it', () => {
+            const firstCell = getContainerCell(grid.$.items, 1, 0);
+            dblclick(firstCell._content);
+            input = getCellEditor(firstCell);
+
+            input.addEventListener('keydown', e => e.keyCode === 9 && e.preventDefault());
+            tab(input);
+            expect(getCellEditor(firstCell)).to.be.ok;
+          });
+
+          it('should not focus cell next available for editing on Tab if `internal-tab` was fired right before it', () => {
+            const firstCell = getContainerCell(grid.$.items, 1, 0);
+            dblclick(firstCell._content);
+            input = getCellEditor(firstCell);
+
+            input.dispatchEvent(new CustomEvent('internal-tab'));
+            tab(input);
+            expect(getCellEditor(firstCell)).to.be.ok;
+          });
+
+          it('should be possible to switch edit cell on Tab with delay after `internal-tab` was fired', done => {
+            const firstCell = getContainerCell(grid.$.items, 1, 0);
+            dblclick(firstCell._content);
+            input = getCellEditor(firstCell);
+
+            input.dispatchEvent(new CustomEvent('internal-tab'));
+            const secondCell = getContainerCell(grid.$.items, 1, 1);
+            window.requestAnimationFrame(() => {
+              tab(input);
+              expect(getCellEditor(secondCell)).to.be.ok;
+              done();
+            });
+          });
+
           it('should focus previous cell available for editing within a same row in edit mode on Shift Tab', () => {
             const firstCell = getContainerCell(grid.$.items, 1, 1);
             dblclick(firstCell._content);


### PR DESCRIPTION
**Clarifications**:
1. `_editTemplateObserver` is now flushed in `ready` as `connectedCallback` is too early. One test is failing to prove that.
2. Listening to `internal-tabbing` in order to stop switching when working with `vaadin-custom-field`. Based on https://github.com/vaadin/vaadin-custom-field/pull/32
3. Also fixes #94 
