### PR TITLE
fix: ensure cell is re-focused after exit edit mode

### DIFF
--- a/src/vaadin-grid-pro-inline-editing-mixin.html
+++ b/src/vaadin-grid-pro-inline-editing-mixin.html
@@ -68,6 +68,27 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
     }
 
     ready() {
+      // add listener before `vaadin-grid` interaction mode listener
+      this.addEventListener('keydown', e => {
+        switch (e.keyCode) {
+          case 27:
+            this.__edited && this._stopEdit(true);
+            break;
+          case 9:
+            this.__edited && this._switchEditCell(e);
+            break;
+          case 13:
+            this.__edited ? this._switchEditCell(e) : this._enterEditFromEvent(e);
+            break;
+          case 32:
+            !this.__edited && this._enterEditFromEvent(e);
+            break;
+          default:
+            e.key && e.key.length === 1 && this._enterEditFromEvent(e, 'text');
+            break;
+        }
+      });
+
       super.ready();
 
       // Prevent click/selection on edit column
@@ -105,26 +126,6 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           this._enterEditFromEvent(e);
         });
       }
-
-      this.addEventListener('keydown', e => {
-        switch (e.keyCode) {
-          case 27:
-            this.__edited && this._stopEdit(true);
-            break;
-          case 9:
-            this.__edited && this._switchEditCell(e);
-            break;
-          case 13:
-            this.__edited ? this._switchEditCell(e) : this._enterEditFromEvent(e);
-            break;
-          case 32:
-            !this.__edited && this._enterEditFromEvent(e);
-            break;
-          default:
-            e.key && e.key.length === 1 && this._enterEditFromEvent(e, 'text');
-            break;
-        }
-      });
     }
 
     _checkImports() {

--- a/test/edit-column.html
+++ b/test/edit-column.html
@@ -378,6 +378,19 @@
           expect(getCellEditor(firstCell)).to.be.not.ok;
         });
 
+        it('should re-focus cell after exit edit mode on ESC', () => {
+          const firstCell = getContainerCell(grid.$.items, 1, 0);
+          firstCell.focus();
+          enter(firstCell._content);
+          input = getCellEditor(firstCell);
+
+          const focusSpy = sinon.spy(firstCell, 'focus');
+          const stopSpy = sinon.spy(grid, '_stopEdit');
+          esc(input);
+
+          expect(focusSpy.calledAfter(stopSpy)).to.be.true;
+        });
+
         it('should focus correct editable cell after column reordering', () => {
           grid.singleCellEdit = true;
           grid.columnReorderingAllowed = true;


### PR DESCRIPTION
Fixes #18 

It looks like Edge 18 has a bug with focus events not dispatched when focused node is removed from the DOM, at least I was able to reproduce that with `focusout`:

https://jsbin.com/socokoq/edit?html,js,console,output

Furthermore, we do not have all the focus events in place in the tests, so the issue is tricky to reproduce using mock events only.

The suggested fix is to add `keydown` listener in `vaadin-grid-pro` before it is added by `vaadin-grid`, to ensure that restoring cell focus by `vaadin-grid` happens **after** editor removal on <kbd>Esc</kbd>.