### PR TITLE
refactor: only run license checker when needed

### DIFF
--- a/src/vaadin-grid-pro.html
+++ b/src/vaadin-grid-pro.html
@@ -38,6 +38,19 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         static get version() {
           return '2.0.4';
         }
+
+        /**
+         * @protected
+         */
+        static _finalizeClass() {
+          super._finalizeClass();
+
+          const devModeCallback = window.Vaadin.developmentModeCallback;
+          const licenseChecker = devModeCallback && devModeCallback['vaadin-license-checker'];
+          if (typeof licenseChecker === 'function') {
+            licenseChecker(GridProElement);
+          }
+        }
       }
 
       customElements.define(GridProElement.is, GridProElement);
@@ -47,12 +60,6 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
        */
       window.Vaadin = window.Vaadin || {};
       window.Vaadin.GridProElement = GridProElement;
-
-      const devModeCallback = window.Vaadin.developmentModeCallback;
-      const licenseChecker = devModeCallback && devModeCallback['vaadin-license-checker'];
-      if (typeof licenseChecker === 'function') {
-        licenseChecker(GridProElement);
-      }
     })();
   </script>
 </dom-module>


### PR DESCRIPTION
Connected to vaadin/components-team-tasks#492

This PR makes sure the license checker is only called when the component is created.
The static `_finalizeClass` method is needed to ensure we call it [once per class](https://github.com/Polymer/polymer/blob/f6ccc9d1bdc81e934e21bf27b3dba517b5840fd4/lib/mixins/properties-mixin.js#L138-L147).