### PR TITLE
feat: prepare for TS defs generation [skip ci]

### DIFF
--- a/@types/interfaces.d.ts
+++ b/@types/interfaces.d.ts
@@ -1,0 +1,1 @@
+export type GridProEditorType = 'text' | 'checkbox' | 'select' | 'custom';

--- a/bower.json
+++ b/bower.json
@@ -28,17 +28,17 @@
   ],
   "dependencies": {
     "polymer": "^2.0.0",
-    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.5.2",
-    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.3.0",
+    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.6.1",
+    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.4.1",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.6.0",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.3.2",
     "vaadin-license-checker": "vaadin/license-checker#^2.1.0",
-    "vaadin-text-field": "vaadin/vaadin-text-field#^2.6.0",
-    "vaadin-select": "vaadin/vaadin-select#^2.2.0",
-    "vaadin-list-box": "vaadin/vaadin-list-box#^1.3.0",
-    "vaadin-item": "vaadin/vaadin-item#^2.2.0",
-    "vaadin-grid": "vaadin/vaadin-grid#^5.6.0",
-    "vaadin-checkbox": "vaadin/vaadin-checkbox#^2.3.0"
+    "vaadin-text-field": "vaadin/vaadin-text-field#^2.7.0-alpha1",
+    "vaadin-select": "vaadin/vaadin-select#^2.3.0-alpha1",
+    "vaadin-list-box": "vaadin/vaadin-list-box#^1.4.0-alpha1",
+    "vaadin-item": "vaadin/vaadin-item#^2.3.0-alpha1",
+    "vaadin-grid": "vaadin/vaadin-grid#^5.7.0-alpha1",
+    "vaadin-checkbox": "vaadin/vaadin-checkbox#^2.4.0-alpha1"
   },
   "devDependencies": {
     "iron-component-page": "^3.0.0",

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,0 +1,22 @@
+{
+  "excludeFiles": [
+    "wct.conf.js",
+    "index.html",
+    "src/vaadin-grid-pro-edit-checkbox.js",
+    "src/vaadin-grid-pro-edit-select.js",
+    "src/vaadin-grid-pro-edit-text-field.js",
+    "demo/**/*",
+    "test/**/*",
+    "theme/**/*"
+  ],
+  "autoImport": {
+    "@vaadin/vaadin-grid/@types/interfaces": [
+      "GridBodyRenderer",
+      "GridItem",
+      "GridRowData"
+    ],
+    "./@types/interfaces": [
+      "GridProEditorType"
+    ]
+  }
+}

--- a/magi-p3-post.js
+++ b/magi-p3-post.js
@@ -1,0 +1,18 @@
+module.exports = {
+  files: [
+    'src/vaadin-grid-pro.js',
+    'src/vaadin-grid-pro-edit-column.js',
+    'vaadin-grid-pro.js',
+    'vaadin-grid-pro-edit-column.js'
+  ],
+  from: [
+    /@mixes Vaadin\.GridPro\./g,
+    /@memberof Vaadin*\n.*@extends Vaadin\./g,
+    /import '\.\/theme\/lumo\/vaadin-(.+)\.js';/
+  ],
+  to: [
+    '@mixes ',
+    '@extends ',
+    `import './theme/lumo/vaadin-$1.js';\nexport * from './src/vaadin-$1.js';`
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   },
   "homepage": "https://vaadin.com/components",
   "files": [
+    "vaadin-*.d.ts",
     "vaadin-*.js",
+    "@types",
     "src",
     "theme"
   ],

--- a/polymer.json
+++ b/polymer.json
@@ -1,0 +1,5 @@
+{
+  "lint": {
+    "ignoreWarnings": ["overriding-private"]
+  }
+}

--- a/src/vaadin-grid-pro-edit-column.html
+++ b/src/vaadin-grid-pro-edit-column.html
@@ -53,7 +53,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
            *   - `rowData.expanded` Sublevel toggle state.
            *   - `rowData.level` Level of the tree represented with a horizontal offset of the toggle button.
            *   - `rowData.selected` Selected state.
-           * @type {!GridBodyRenderer | undefined}
+           * @type {!GridBodyRenderer | null | undefined}
            */
           editModeRenderer: Function,
 
@@ -290,7 +290,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
       /**
        * @param {!HTMLElement} editor
-       * @return {string | undefined}
+       * @return {unknown}
        * @protected
        */
       _getEditorValue(editor) {

--- a/src/vaadin-grid-pro-edit-column.html
+++ b/src/vaadin-grid-pro-edit-column.html
@@ -53,12 +53,14 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
            *   - `rowData.expanded` Sublevel toggle state.
            *   - `rowData.level` Level of the tree represented with a horizontal offset of the toggle button.
            *   - `rowData.selected` Selected state.
+           * @type {!GridBodyRenderer | undefined}
            */
           editModeRenderer: Function,
 
           /**
            * The list of options which should be passed to cell editor component.
            * Used with the `select` editor type, to provide a list of items.
+           * @type {!Array<string>}
            */
           editorOptions: {
             type: Array,
@@ -73,6 +75,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
            *
            * Editor type is set to `custom` when either `editModeRenderer` is set,
            * or editor template provided for the column.
+           * @type {!GridProEditorType}
            */
           editorType: {
             type: String,
@@ -82,6 +85,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
           /**
            * Path of the property used for the value of the editor component.
+           * @type {string}
            */
           editorValuePath: {
             type: String,
@@ -96,8 +100,10 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             observer: '_pathChanged'
           },
 
+          /** @private */
           _oldTemplate: Object,
 
+          /** @private */
           _oldRenderer: Function
         };
       }
@@ -135,12 +141,14 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         this._editTemplateObserver.flush();
       }
 
+      /** @private */
       _pathChanged(path) {
         if (!path || path.length == 0) {
           throw new Error('You should specify the path for the edit column');
         }
       }
 
+      /** @private */
       _cellsChanged() {
         this._cells.forEach(cell => {
           const part = cell.getAttribute('part');
@@ -150,6 +158,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         });
       }
 
+      /** @private */
       _removeNewRendererOrTemplate(template, oldTemplate, renderer, oldRenderer) {
         if (template !== oldTemplate) {
           this._editModeTemplate = undefined;
@@ -158,6 +167,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         }
       }
 
+      /** @private */
       _editModeTemplateOrRendererChanged(template, renderer) {
         if (template === undefined && renderer === undefined && !this._oldTemplate && !this._oldRenderer) {
           return;
@@ -177,6 +187,8 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
       /**
        * Override body template preparation to take editor into account.
+       * @return {HTMLTemplateElement}
+       * @protected
        */
       _prepareBodyTemplate() {
         return this._prepareTemplatizer(this._findTemplate(false, false, false) || null);
@@ -184,6 +196,11 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
       /**
        * Override template filtering to take editor into account.
+       * @param {boolean} header
+       * @param {boolean} footer
+       * @param {boolean} editor
+       * @return {HTMLTemplateElement}
+       * @protected
        */
       _selectFirstTemplate(header = false, footer = false, editor = false) {
         return Polymer.FlattenedNodesObserver.getFlattenedNodes(this)
@@ -197,6 +214,11 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
       /**
        * Override template search to take editor into account.
+       * @param {boolean} header
+       * @param {boolean} footer
+       * @param {boolean=} editor
+       * @return {HTMLTemplateElement}
+       * @protected
        */
       _findTemplate(header, footer, editor) {
         const template = this._selectFirstTemplate(header, footer, editor);
@@ -209,22 +231,34 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         return template;
       }
 
+      /** @private */
       _prepareEditModeTemplate() {
         return this._prepareTemplatizer(this._findTemplate(false, false, true) || null, {});
       }
 
+      /**
+       * @param {!HTMLElement} cell
+       * @return {string}
+       * @protected
+       */
       _getEditorTagName(cell) {
         return this.editorType === 'custom' ?
           this._getEditorComponent(cell).localName :
           this._getTagNameByType();
       }
 
+      /**
+       * @param {!HTMLElement} cell
+       * @return {HTMLElement | null}
+       * @protected
+       */
       _getEditorComponent(cell) {
         return this.editorType === 'custom' ?
           cell._content.firstElementChild :
           cell._content.querySelector(this._getEditorTagName(cell));
       }
 
+      /** @private */
       _getTagNameByType() {
         let type;
         switch (this.editorType) {
@@ -242,6 +276,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         return this.constructor.is.replace('column', type);
       }
 
+      /** @private */
       _focusEditor(editor) {
         editor.focus();
         if (this.editorType === 'checkbox') {
@@ -253,11 +288,17 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         }
       }
 
+      /**
+       * @param {!HTMLElement} editor
+       * @return {string | undefined}
+       * @protected
+       */
       _getEditorValue(editor) {
         const path = this.editorType === 'checkbox' ? 'checked' : this.editorValuePath;
         return Polymer.Path.get(editor, path);
       }
 
+      /** @private */
       _renderEditor(cell, model) {
         if (cell._template) {
           cell.__savedTemplate = cell._template;
@@ -275,6 +316,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         }
       }
 
+      /** @private */
       _removeEditor(cell, model) {
         if (cell.__savedTemplate) {
           this._stampTemplateToCell(cell, cell.__savedTemplate, model);
@@ -287,12 +329,14 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         }
       }
 
+      /** @private */
       _setEditorOptions(editor) {
         if (this.editorOptions && this.editorOptions.length) {
           editor.options = this.editorOptions;
         }
       }
 
+      /** @private */
       _setEditorValue(editor, value) {
         const path = this.editorType === 'checkbox' ? 'checked' : this.editorValuePath;
         // FIXME(yuriy): Required for the flow counterpart as it is passing the string value to webcomponent
@@ -301,6 +345,11 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         editor.notifyPath && editor.notifyPath(path, value);
       }
 
+      /**
+       * @param {!HTMLElement} cell
+       * @param {!GridRowData} model
+       * @protected
+       */
       _startCellEdit(cell, model) {
         this._renderEditor(cell, model);
         this._grid.notifyResize();
@@ -315,6 +364,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         this._focusEditor(editor);
       }
 
+      /** @private */
       _stampTemplateToCell(cell, template, model) {
         cell._template = template;
         cell._content.innerHTML = '';
@@ -326,12 +376,18 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         cell._instance.setProperties(model);
       }
 
+      /** @private */
       _stampRendererToCell(cell, renderer, model) {
         cell._content.innerHTML = '';
         cell._renderer = renderer;
         this.__runRenderer(renderer, cell, model);
       }
 
+      /**
+       * @param {!HTMLElement} cell
+       * @param {!GridRowData} model
+       * @protected
+       */
       _stopCellEdit(cell, model) {
         const editor = this._getEditorComponent(cell);
         let shouldResize = true;

--- a/src/vaadin-grid-pro-inline-editing-mixin.html
+++ b/src/vaadin-grid-pro-inline-editing-mixin.html
@@ -45,6 +45,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           notify: true // FIXME(yuriy-fix): needed by Flow counterpart
         },
 
+        /** @private */
         _editingDisabled: {
           type: Boolean
         }
@@ -71,6 +72,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       });
     }
 
+    /** @protected */
     ready() {
       // add listener before `vaadin-grid` interaction mode listener
       this.addEventListener('keydown', e => {
@@ -132,6 +134,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       }
     }
 
+    /** @protected */
     _checkImports() {
       super._checkImports();
       [
@@ -144,11 +147,13 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       });
     }
 
+    /** @private */
     _applyEdit({path, value, index, item}) {
       this.set(path, value, item);
       this.notifyPath('items.' + index + '.' + path, value);
     }
 
+    /** @private */
     _addEditColumnListener(type, callback) {
       this.addEventListener(type, e => {
         const context = this.getEventContext(e);
@@ -172,20 +177,24 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       });
     }
 
+    /** @private */
     _onItemPropertyChanged(e) {
       if (!e.defaultPrevented) {
         this._applyEdit(e.detail);
       }
     }
 
+    /** @private */
     _getRowByIndex(index) {
       return Array.from(this.$.items.children).filter(el => el.index === index)[0];
     }
 
+    /** @private */
     _isEditColumn(column) {
       return column.localName.toLowerCase() === 'vaadin-grid-pro-edit-column';
     }
 
+    /** @private */
     _getEditColumns() {
       const columnTreeLevel = this._columnTree.length - 1;
       return this._columnTree[columnTreeLevel]
@@ -193,6 +202,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         .sort((a, b) => a._order - b._order);
     }
 
+    /** @private */
     _cancelStopEdit() {
       // stop edit on outside click will always trigger notify resize.
       // when tabbing within same row it might not be needed, so cancel
@@ -202,6 +212,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       }
     }
 
+    /** @private */
     _flushStopEdit() {
       if (this._debouncerStopEdit) {
         this._debouncerStopEdit.flush();
@@ -209,6 +220,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       }
     }
 
+    /** @private */
     _enterEditFromEvent(e, type) {
       const context = this.getEventContext(e);
       const column = context.column;
@@ -238,6 +250,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       }
     }
 
+    /** @private */
     _onEditorFocusOut() {
       // schedule stop on editor component focusout
       this._debouncerStopEdit = Polymer.Debouncer.debounce(
@@ -246,10 +259,12 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         this._stopEdit.bind(this));
     }
 
+    /** @private */
     _onEditorFocusIn(e) {
       this._cancelStopEdit();
     }
 
+    /** @private */
     _onGlobalFocusIn(e) {
       const edited = this.__edited;
       if (edited) {
@@ -264,6 +279,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       }
     }
 
+    /** @private */
     _startEdit(cell, column) {
       if (this._editingDisabled) {
         return;
@@ -288,6 +304,11 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       this.addEventListener('item-property-changed', this.__boundItemPropertyChanged);
     }
 
+    /**
+     * @param {boolean=} shouldCancel
+     * @param {boolean=} shouldRestoreFocus
+     * @protected
+     */
     _stopEdit(shouldCancel, shouldRestoreFocus) {
       if (!this.__edited) {
         return;
@@ -325,11 +346,16 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       }
     }
 
+    /** @private */
     _setCancelCellSwitch() {
       this.__cancelCellSwitch = true;
       window.requestAnimationFrame(() => this.__cancelCellSwitch = false);
     }
 
+    /**
+     * @param {!KeyboardEvent} e
+     * @protected
+     */
     _switchEditCell(e) {
       if (this.__cancelCellSwitch ||
           e.defaultPrevented && e.keyCode === 9) {
@@ -398,6 +424,11 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       }
     }
 
+    /**
+     * @param {!HTMLElement} row
+     * @param {GridItem} item
+     * @protected
+     */
     _updateItem(row, item) {
       if (this.__edited) {
         const {cell, model} = this.__edited;


### PR DESCRIPTION
Fixes #116 

Generated TS definitions look like this:

### `vaadin-grid-pro-edit-column.d.ts`

```ts
import {FlattenedNodesObserver} from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';

import {get, set} from '@polymer/polymer/lib/utils/path.js';

import {GridColumnElement} from '@vaadin/vaadin-grid/src/vaadin-grid-column.js';

declare class GridProEditColumnElement extends GridColumnElement {
  path: string|null|undefined;
  editModeRenderer: GridBodyRenderer|undefined;
  editorOptions: string[];
  editorType: GridProEditorType;
  editorValuePath: string;
  ready(): void;
  _prepareBodyTemplate(): HTMLTemplateElement|null;
  _selectFirstTemplate(header?: boolean, footer?: boolean, editor?: boolean): HTMLTemplateElement|null;
  _findTemplate(header: boolean, footer: boolean, editor?: boolean): HTMLTemplateElement|null;
  _getEditorTagName(cell: HTMLElement): string;
  _getEditorComponent(cell: HTMLElement): HTMLElement|null;
  _getEditorValue(editor: HTMLElement): string|undefined;
  _startCellEdit(cell: HTMLElement, model: GridRowData): void;
  _stopCellEdit(cell: HTMLElement, model: GridRowData): void;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-grid-pro-edit-column": GridProEditColumnElement;
  }
}

export {GridProEditColumnElement};

import {GridBodyRenderer} from '@vaadin/vaadin-grid/@types/interfaces';

import {GridProEditorType} from '../@types/interfaces';

import {GridRowData} from '@vaadin/vaadin-grid/@types/interfaces';
```

### `vaadin-grid-pro-inline-editing-mixin.d.ts`

```ts
import {microTask} from '@polymer/polymer/lib/utils/async.js';

import {Debouncer} from '@polymer/polymer/lib/utils/debounce.js';

import {PolymerElement} from '@polymer/polymer/polymer-element.js';

export {InlineEditingMixin};

declare function InlineEditingMixin<T extends new (...args: any[]) => {}>(base: T): T & InlineEditingMixinConstructor;

interface InlineEditingMixinConstructor {
  new(...args: any[]): InlineEditingMixin;
}

export {InlineEditingMixinConstructor};

interface InlineEditingMixin {
  enterNextRow: boolean|null|undefined;
  singleCellEdit: boolean|null|undefined;
  ready(): void;
  _checkImports(): void;
  _stopEdit(shouldCancel?: boolean, shouldRestoreFocus?: boolean): void;
  _switchEditCell(e: KeyboardEvent): void;
  _updateItem(row: HTMLElement, item: GridItem|null): void;
}

import {GridItem} from '@vaadin/vaadin-grid/@types/interfaces';
```

### `vaadin-grid-pro.d.ts`

```ts

import {GridElement} from '@vaadin/vaadin-grid/src/vaadin-grid.js';

import {InlineEditingMixin} from './vaadin-grid-pro-inline-editing-mixin.js';

declare class GridProElement extends
  InlineEditingMixin(
  GridElement) {
  static _finalizeClass(): void;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-grid-pro": GridProElement;
  }
}

export {GridProElement};
```