### PR TITLE
fix: call blur from editor to trigger change event

### DIFF
--- a/src/vaadin-grid-pro-inline-editing-mixin.html
+++ b/src/vaadin-grid-pro-inline-editing-mixin.html
@@ -322,6 +322,13 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         if (editor) {
           const value = column._getEditorValue(editor);
           if (value !== this.get(column.path, model.item)) {
+            // In some cases, where the value comes from the editor's change
+            // event (eg. custom editor in vaadin-grid-pro-flow), the event is
+            // not dispatched in FF/Safari/Edge. That's due the change event
+            // doesn't occur when the editor is removed from the DOM. Manually
+            // calling blur makes the event to be dispatched.
+            editor.blur();
+
             this.dispatchEvent(new CustomEvent('item-property-changed', {
               detail: {
                 index: model.index,

--- a/test/edit-column.html
+++ b/test/edit-column.html
@@ -435,6 +435,38 @@
           tab(input);
           expect(spy).to.be.calledOnce;
         });
+
+        it('should trigger "focusout" event from the editor when leaving focus on Tab', () => {
+          const firstCell = getContainerCell(grid.$.items, 1, 0);
+          dblclick(firstCell._content);
+          input = getCellEditor(firstCell);
+          const spy = sinon.spy();
+          input.addEventListener('focusout', spy);
+
+          input.value = 'abc';
+          tab(input);
+
+          expect(spy).to.be.calledOnce;
+          expect(spy.args[0][0].target).to.be.equal(input);
+
+          grid.removeEventListener('focusout', spy);
+        });
+
+        it('should trigger "focusout" event from the editor when leaving focus on Enter', () => {
+          const firstCell = getContainerCell(grid.$.items, 1, 0);
+          dblclick(firstCell._content);
+          input = getCellEditor(firstCell);
+          const spy = sinon.spy();
+          input.addEventListener('focusout', spy);
+
+          input.value = 'abc';
+          enter(input);
+
+          expect(spy).to.be.calledOnce;
+          expect(spy.args[0][0].target).to.be.equal(input);
+
+          grid.removeEventListener('focusout', spy);
+        });
       });
 
       describe('wrapped fields in custom editor', () => {

--- a/test/edit-column.html
+++ b/test/edit-column.html
@@ -447,8 +447,6 @@
           tab(input);
 
           expect(spy).to.be.calledOnce;
-          expect(spy.args[0][0].target).to.be.equal(input);
-
           grid.removeEventListener('focusout', spy);
         });
 
@@ -463,7 +461,6 @@
           enter(input);
 
           expect(spy).to.be.calledOnce;
-          expect(spy.args[0][0].target).to.be.equal(input);
 
           grid.removeEventListener('focusout', spy);
         });

--- a/test/edit-column.html
+++ b/test/edit-column.html
@@ -435,35 +435,6 @@
           tab(input);
           expect(spy).to.be.calledOnce;
         });
-
-        it('should trigger "focusout" event from the editor when leaving focus on Tab', () => {
-          const firstCell = getContainerCell(grid.$.items, 1, 0);
-          dblclick(firstCell._content);
-          input = getCellEditor(firstCell);
-          const spy = sinon.spy();
-          input.addEventListener('focusout', spy);
-
-          input.value = 'abc';
-          tab(input);
-
-          expect(spy).to.be.calledOnce;
-          grid.removeEventListener('focusout', spy);
-        });
-
-        it('should trigger "focusout" event from the editor when leaving focus on Enter', () => {
-          const firstCell = getContainerCell(grid.$.items, 1, 0);
-          dblclick(firstCell._content);
-          input = getCellEditor(firstCell);
-          const spy = sinon.spy();
-          input.addEventListener('focusout', spy);
-
-          input.value = 'abc';
-          enter(input);
-
-          expect(spy).to.be.calledOnce;
-
-          grid.removeEventListener('focusout', spy);
-        });
       });
 
       describe('wrapped fields in custom editor', () => {


### PR DESCRIPTION
Part of https://github.com/vaadin/vaadin-grid-pro-flow/issues/94.

`vaadin-grid-pro-flow` relies on getting the custom editor value from the server side and most of Vaadin components (if not all), by default, updates its value from a change event on the client side. The way the editor is removed on pressing `Tab`/`Enter`, browsers such Firefox and Safari won't trigger a `change` event when the DOM element is removed. Forcing a call to `editor.blur()` before the element is removed could solve this issue.