### PR TITLE
test: workaround a grid regression

### DIFF
--- a/test/edit-column-renderer.test.js
+++ b/test/edit-column-renderer.test.js
@@ -238,7 +238,10 @@ describe('edit column renderer', () => {
     });
 
     it('should close editor and update value when scrolling edited cell out of view', () => {
+      grid.items = null;
       grid.items = Array.apply(null, { length: 30 }).map(() => Object.assign({}, createItems()[0]));
+      flushGrid(grid);
+
       cell = getContainerCell(grid.$.items, 0, 0);
       column.editModeRenderer = function (root) {
         root.innerHTML = '<input>';


### PR DESCRIPTION
Fixes #161 

The test seems to create some kind of an edge case that makes the grid generate more physical rows than usually. This has something to do with reassigning the `items` in the test right after it's been assigned in the beforeEach block (with a smaller array). This is still a regression from https://github.com/vaadin/vaadin-grid/commit/38a01c5ab889cf088e76a3e675ee94fe60a273b8 and has a [separate issue](https://github.com/vaadin/vaadin-grid/issues/2134) report in `vaadin-grid`

Fix for the test; set items `null` before reassigning it to workaround the issue.