### PR TITLE
 fix: change timing for the stopEdit() call on focusOut cell editor (CP:  #165)

### DIFF
--- a/src/vaadin-grid-pro-inline-editing-mixin.html
+++ b/src/vaadin-grid-pro-inline-editing-mixin.html
@@ -270,7 +270,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       // schedule stop on editor component focusout
       this._debouncerStopEdit = Polymer.Debouncer.debounce(
         this._debouncerStopEdit,
-        Polymer.Async.microTask,
+        Polymer.Async.animationFrame,
         this._stopEdit.bind(this));
     }
 

--- a/test/edit-column-overlay.html
+++ b/test/edit-column-overlay.html
@@ -71,9 +71,12 @@
     }
 
     // Mimic clicking the overlay
-    function clickOverlay(element) {
+    async function clickOverlay(element) {
       const focusout = new CustomEvent('focusout', {bubbles: true, composed: true});
       element.dispatchEvent(focusout);
+
+      // add a microTask in between
+      await Promise.resolve();
 
       const focusin = new CustomEvent('focusin', {bubbles: true, composed: true});
       element.$.overlay.dispatchEvent(focusin);
@@ -103,13 +106,15 @@
           }
         });
 
-        it('should not stop editing when focusing input related overlay', () => {
+        it('should not stop editing when focusing input related overlay', async() => {
           enter(dateCell);
           const datePicker = getCellEditor(dateCell).querySelector('vaadin-date-picker');
           datePicker.click();
 
-          clickOverlay(datePicker);
+          await clickOverlay(datePicker);
           grid._debouncerStopEdit && grid._debouncerStopEdit.flush();
+
+          await new Promise(requestAnimationFrame);
 
           expect(getCellEditor(dateCell)).to.be.ok;
         });

--- a/test/edit-column-renderer.html
+++ b/test/edit-column-renderer.html
@@ -276,7 +276,10 @@
         });
 
         it('should close editor and update value when scrolling edited cell out of view', () => {
+          grid.items = null;
           grid.items = Array.apply(null, {length: 30}).map(_ => Object.assign({}, getItems()[0]));
+          flushGrid(grid);
+
           cell = getContainerCell(grid.$.items, 0, 0);
           column.editModeRenderer = function(root, owner, model) {
             root.innerHTML = '<input>';

--- a/test/index.html
+++ b/test/index.html
@@ -11,12 +11,7 @@
 
 <body>
   <script>
-    WCT.loadSuites(
-      window.GridProElementSuites
-        .reduce(function(suites, suite) {
-          return suites.concat([suite, `${suite}?wc-shadydom=true`]);
-        }, [])
-    );
+    WCT.loadSuites(window.GridProElementSuites);
   </script>
 </body>
 


### PR DESCRIPTION
* fix: clear items list before calling `Array.apply()` and flush grid