### PR TITLE
fix: remove renderer before stamping template

### DIFF
--- a/src/vaadin-grid-pro-edit-column.html
+++ b/src/vaadin-grid-pro-edit-column.html
@@ -321,8 +321,8 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       /** @private */
       _removeEditor(cell, model) {
         if (cell.__savedTemplate) {
-          this._stampTemplateToCell(cell, cell.__savedTemplate, model);
           cell._renderer = undefined;
+          this._stampTemplateToCell(cell, cell.__savedTemplate, model);
           cell.__savedTemplate = undefined;
         } else if (cell.__savedRenderer) {
           this._stampRendererToCell(cell, cell.__savedRenderer, model);

--- a/test/edit-column-template.html
+++ b/test/edit-column-template.html
@@ -140,6 +140,19 @@
           expect(getCellEditor(cell)).to.be.not.ok;
           expect(cell._content.textContent).to.equal(old);
         });
+
+        it('should restore template and remove editor when editing stopped after selection', () => {
+          const old = cell._content.textContent;
+          enter(cell);
+          grid.selectItem(grid.items[0]);
+          // Emulating stop editing with focusout
+          getCellEditor(cell).dispatchEvent(new CustomEvent('focusout', {bubbles: true, composed: true}));
+          grid._flushStopEdit();
+          expect(cell._renderer).to.be.not.ok;
+          expect(cell._template).to.equal(column._bodyTemplate);
+          expect(getCellEditor(cell)).to.be.not.ok;
+          expect(cell._content.textContent).to.equal(old);
+        });
       });
 
       describe('custom edit mode template', () => {


### PR DESCRIPTION
Fixes https://github.com/vaadin/flow-components/issues/4907

Note: bug is reproducible only in v14

It is possible from time to time reproduce the issue with the provided reproducible example application (network throttling should be enabled).
Following the best guess on what is causing that the simplified version of the example is created (forked from the provided repo):
- https://github.com/yuriy-fix/grid-pro-issue/blob/main/src/main/java/org/vaadin/example/MainView.java
- https://github.com/yuriy-fix/grid-pro-issue/blob/main/src/test/java/org/vaadin/example/MainViewIT.java (test to constantly reproduce the issue)

Selecting an item when editor is opened will lead to an item update with editor renderer (within `_updateItem`) via model assignment. Need to make sure that editor renderer is already removed at that point of time.

